### PR TITLE
Update unknown ref workaround. Correct Et calculation in SCAnalyzer.

### DIFF
--- a/RecHitAnalyzer/interface/RecHitAnalyzer.h
+++ b/RecHitAnalyzer/interface/RecHitAnalyzer.h
@@ -200,9 +200,8 @@ class RecHitAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
     std::vector<float> vHBHE_energy_EB_;
     std::vector<float> vHBHE_energy_;
     std::vector<float> vHBHE_EMenergy_;
-    //std::vector<float> vFC_inputs_;
+    std::vector<float> vFC_inputs_;
     math::PtEtaPhiELorentzVectorD vPho_[2];
-    //float vFC_inputs_[5];
   
     // Selection and filling functions
     bool runSelections( const edm::Event&, const edm::EventSetup& );
@@ -214,7 +213,7 @@ class RecHitAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
     void fillECALatHCAL();
     void fillECALstitched();
     void fillEBdigis( const edm::Event&, const edm::EventSetup& );
-    //void fillFC( const edm::Event&, const edm::EventSetup& );
+    void fillFC( const edm::Event&, const edm::EventSetup& );
 
 }; // class RecHitAnalyzer
 

--- a/RecHitAnalyzer/plugins/RecHitAnalyzer.cc
+++ b/RecHitAnalyzer/plugins/RecHitAnalyzer.cc
@@ -97,6 +97,8 @@ RecHitAnalyzer::RecHitAnalyzer(const edm::ParameterSet& iConfig)
   h_E   = fs->make<TH1D>("h_E"  , "E;E;Particles"        , 100,  0., 800.);
   h_eta = fs->make<TH1D>("h_eta", "#eta;#eta;Particles"  , 100, -5., 5.);
   h_m0  = fs->make<TH1D>("h_m0" , "m0;m0;Events"        ,   72, 50., 950.);
+  //h_m0  = fs->make<TH1D>("h_m0" , "m0;m0;Events"        ,   50, 90., 240.);
+  //h_m0  = fs->make<TH1D>("h_m0" , "m0;m0;Events"        ,   50, 0., 2.); 
   h_leadJetPt  = fs->make<TH1D>("h_leadJetPt" , "p_{T};p_{T};Events", 100,  0., 500.);
 
   // Single-event histograms
@@ -146,7 +148,7 @@ RecHitAnalyzer::RecHitAnalyzer(const edm::ParameterSet& iConfig)
   RHTree->Branch("HBHE_EMenergy",  &vHBHE_EMenergy_);
 
   // For FC inputs
-  //RHTree->Branch("FC_inputs",      &vFC_inputs_);
+  RHTree->Branch("FC_inputs",      &vFC_inputs_);
 
 } // constructor
 
@@ -209,7 +211,7 @@ RecHitAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   fillHBHErechits( iEvent, iSetup );
 
   //////////// 4-Momenta //////////
-  //fillFC( iEvent, iSetup );
+  fillFC( iEvent, iSetup );
 
   //////////// Bookkeeping //////////
 
@@ -250,8 +252,8 @@ RecHitAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //descriptions.addDefault(desc);
 }
 
-/*
-//____ Fill FC variables _____//
+
+//____ Fill FC diphoton variables _____//
 void RecHitAnalyzer::fillFC ( const edm::Event& iEvent, const edm::EventSetup& iSetup ) {
 
   edm::Handle<reco::PhotonCollection> photons;
@@ -270,8 +272,7 @@ void RecHitAnalyzer::fillFC ( const edm::Event& iEvent, const edm::EventSetup& i
   }
   vFC_inputs_.push_back( TMath::Cos(vPho_[0].Phi()-vPho_[1].Phi()) );
 
-}
-*/
+} // fillFC() 
 
 //____ Apply event selection cuts _____//
 bool RecHitAnalyzer::runSelections_H24G ( const edm::Event& iEvent, const edm::EventSetup& iSetup ) {
@@ -291,8 +292,8 @@ bool RecHitAnalyzer::runSelections_H24G ( const edm::Event& iEvent, const edm::E
   //float dRCut = 0.4;
   //float dR, dEta, dPhi;
   std::cout << " >> recoPhoCol.size: " << photons->size() << std::endl;
-  //math::PtEtaPhiELorentzVectorD vDiPho;
-  math::XYZTLorentzVector vDiPho;
+  math::PtEtaPhiELorentzVectorD vDiPho;
+  //math::XYZTLorentzVector vDiPho;
   std::vector<float> vE, vPt, vEta, vPhi;
   float leadPhoPt = 0;
 
@@ -365,6 +366,11 @@ bool RecHitAnalyzer::runSelections_H24G ( const edm::Event& iEvent, const edm::E
     diPhoE_  += vE[i];
     diPhoPt_ += vPt[i];
   }
+  //vDiPho = vDiPho/m0_;
+  //vDiPho = vDiPho/diPhoE_;
+  //vDiPho = vDiPho/diPhoPt_;
+  //h_m0->Fill( vDiPho.mass() );
+  //std::cout << " >> m0: " << vDiPho.mass() << " diPhoPt: " << diPhoPt_ << " diPhoE: " << diPhoE_ << std::endl;
   h_m0->Fill( m0_ );
   std::cout << " >> m0: " << m0_ << " diPhoPt: " << diPhoPt_ << " diPhoE: " << diPhoE_ << std::endl;
 
@@ -993,12 +999,12 @@ void RecHitAnalyzer::fillEBdigis ( const edm::Event& iEvent, const edm::EventSet
   // Initialize data collection pointers
   edm::Handle<EBDigiCollection> EBDigisH;
   iEvent.getByToken(EBDigiCollectionT_, EBDigisH);
-
+/*
   // Provides access to global cell position and coordinates below
   edm::ESHandle<CaloGeometry> caloGeomH;
   iSetup.get<CaloGeometryRecord>().get(caloGeomH);
   caloGeom = caloGeomH.product();
-
+*/
   // Initialize arrays
   for(int iS(0); iS < EcalDataFrame::MAXSAMPLES; ++iS)
     vEB_adc_[iS].assign(EBDetId::kSizeForDenseIndexing,0);

--- a/RecHitAnalyzer/plugins/SCAnalyzer.cc
+++ b/RecHitAnalyzer/plugins/SCAnalyzer.cc
@@ -106,7 +106,7 @@ class SCAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
     float vPho_phi_[nPhotons];
 
     // Initialize Calorimeter Geometry
-    const CaloGeometry* caloGeom;
+    //const CaloGeometry* caloGeom;
 };
 
 //
@@ -304,10 +304,12 @@ SCAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   int idx;
   int iphi_shift, ieta_shift;
   int iphi_crop, ieta_crop;
+  /*
   // Provides access to global cell position and coordinates below
   edm::ESHandle<CaloGeometry> caloGeomH;
   iSetup.get<CaloGeometryRecord>().get(caloGeomH);
   caloGeom = caloGeomH.product();
+  */
   for(EcalRecHitCollection::const_iterator iRHit = EBRecHitsH->begin();
       iRHit != EBRecHitsH->end();
       ++iRHit) {
@@ -336,11 +338,11 @@ SCAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
       idx = ieta_crop*crop_size + iphi_crop;
 
       // Cell geometry provides access to (rho,eta,phi) coordinates of cell center
-      auto cell = caloGeom->getGeometry(ebId);
+      //auto cell = caloGeom->getGeometry(ebId);
       
       // Fill branch arrays 
       vSC_energy_[iP][idx] = iRHit->energy();
-      vSC_energyT_[iP][idx] = iRHit->energy()/TMath::CosH(cell->etaPos());
+      vSC_energyT_[iP][idx] = iRHit->energy()/TMath::CosH(vPho_eta_[iP]);
       vSC_time_[iP][idx] = iRHit->time();
       vEB_SCenergy_[ebId.hashedIndex()] = iRHit->energy();
       //std::cout << " >> " << iP << ": iphi_,ieta_,E: " << iphi_crop << ", " << ieta_crop << ", " << iRHit->energy() << std::endl; 

--- a/runSCAnalyzer_All.py
+++ b/runSCAnalyzer_All.py
@@ -1,0 +1,28 @@
+import os
+from glob import glob
+import re
+import argparse
+
+parser = argparse.ArgumentParser(description='Run SCAnalyzer')
+parser.add_argument('-d','--decay', required=True, help='Decay:Single*Pt50',type=str)
+args = parser.parse_args()
+
+eosDir='/eos/uscms/store/user/mba2012'
+decay='%s_FEVTDEBUG'%args.decay
+
+cfg='RecHitAnalyzer/python/SCAnalyzer_cfg.py'
+inputFiles_ = ['file:%s'%path for path in glob('%s/FEVTDEBUG/%s/*/*/step*root'%(eosDir,decay))]
+
+listname = 'list_%s.txt'%decay
+with open(listname, 'w') as list_file:
+    for inputFile in inputFiles_:
+        list_file.write("%s\n" % inputFile)
+
+maxEvents_=-1
+skipEvents_=0
+
+cmd="cmsRun %s inputFiles_load=%s maxEvents=%d skipEvents=%d outputFile=%s/IMGs/%s_IMG.root"%(cfg,listname,maxEvents_,skipEvents_,eosDir,decay)
+#print '%s'%cmd
+os.system(cmd)
+
+#os.system('mv cEB*.eps %s/'%(inputTag))


### PR DESCRIPTION
- Unknown ref bug: now seems to be due to caloGeometry call in fillEBdigis() which is left commented. Previous workarounds have been removed, so fillFC() is now active and vDiPho is of type math::PtEtaPhiELorentzVectorD
- Corrected calculation of Et of hits in SCAnalyzer: use cosh(eta) of particle not of crystal.
- Some additional code for testing 4-momentum scaling left commented
- Added script for running SCAnalyzer on multiple files