### PR TITLE
RHAnalyzer: Split jet seed finding from jet selection

### DIFF
--- a/RecHitAnalyzer/interface/RecHitAnalyzer.h
+++ b/RecHitAnalyzer/interface/RecHitAnalyzer.h
@@ -4,13 +4,12 @@
 //
 // Package:    MLAnalyzer/RecHitAnalyzer
 // Class:      RecHitAnalyzer
-// 
+//
 //
 // Original Author:  Michael Andrews
 //         Created:  Sat, 14 Jan 2017 17:45:54 GMT
 //
 //
-
 
 // system include files
 #include <memory>
@@ -71,6 +70,7 @@
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h" // reco::PhotonCollection defined here
 #include "DataFormats/JetReco/interface/PFJet.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/JetReco/interface/GenJet.h"
 #include "DataFormats/JetReco/interface/GenJetCollection.h"
 #include "DataFormats/Math/interface/deltaR.h"
@@ -94,7 +94,6 @@ class RecHitAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-
   private:
     virtual void beginJob() override;
     virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
@@ -116,12 +115,6 @@ class RecHitAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
     typedef std::vector<reco::PFCandidate>  PFCollection;
     edm::EDGetTokenT<PFCollection> pfCollectionT_;
     //edm::InputTag trackTags_; //used to select what tracks to read from configuration file
-
-    double minJetPt_;
-    double maxJetEta_;
-    std::string mode_ = "EventLevel";  // EventLevel / JetLevel
-    bool doJets_;
-    int  nJets_;
 
     // Diagnostic histograms
     //TH2D * hEB_adc[EcalDataFrame::MAXSAMPLES]; 
@@ -174,6 +167,21 @@ class RecHitAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
     const reco::PFCandidate* getPFCand(edm::Handle<PFCollection> pfCands, float eta, float phi, float& minDr, bool debug = false);
     const reco::Track* getTrackCand(edm::Handle<reco::TrackCollection> trackCands, float eta, float phi, float& minDr, bool debug = false);
 
+    // Jet level functions
+    std::string mode_;  // EventLevel / JetLevel
+    bool doJets_;
+    int  nJets_;
+    double minJetPt_;
+    double maxJetEta_;
+    std::vector<int> vJetIdxs;
+    void branchesEvtSel_jet_dijet      ( TTree*, edm::Service<TFileService>& );
+    void branchesEvtSel_jet_dijet_gg_qq( TTree*, edm::Service<TFileService>& );
+    bool runEvtSel_jet_dijet      ( const edm::Event&, const edm::EventSetup& );
+    bool runEvtSel_jet_dijet_gg_qq( const edm::Event&, const edm::EventSetup& );
+    void fillEvtSel_jet_dijet      ( const edm::Event&, const edm::EventSetup& );
+    void fillEvtSel_jet_dijet_gg_qq( const edm::Event&, const edm::EventSetup& );
+
+    int nTotal, nPassed;
 
 }; // class RecHitAnalyzer
 
@@ -181,6 +189,7 @@ class RecHitAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
 // constants, enums and typedefs
 //
 static const bool debug = true;
+//static const bool debug = false;
 
 static const int nEE = 2;
 static const int nTOB = 6;

--- a/RecHitAnalyzer/plugins/BuildFile.xml
+++ b/RecHitAnalyzer/plugins/BuildFile.xml
@@ -7,6 +7,7 @@
  <use name="DataFormats/EcalRecHit"/>
  <use name="DataFormats/HcalDetId"/>
  <use name="DataFormats/HcalRecHit"/>
+ <use name="DataFormats/ParticleFlowCandidate"/>
  <use name="DQM/HcalCommon"/>
  <use name="Geometry/CaloGeometry"/>
  <use name="Geometry/Records"/>

--- a/RecHitAnalyzer/plugins/RHAnalyzer_runEvtSel.cc
+++ b/RecHitAnalyzer/plugins/RHAnalyzer_runEvtSel.cc
@@ -40,14 +40,14 @@ void RecHitAnalyzer::branchesEvtSel ( TTree* tree, edm::Service<TFileService> &f
   h_nJet   = fs->make<TH1F>("h_nJet"  , "nJet;nJet;Events"     ,  10,  0.,  10.);
   */
 
-  RHTree->Branch("eventId",        &eventId_);
-  RHTree->Branch("runId",          &runId_);
-  RHTree->Branch("lumiId",         &lumiId_);
-  RHTree->Branch("m0",             &m0_);
-  //RHTree->Branch("nJet",           &nJet_);
-  RHTree->Branch("FC_inputs",      &vFC_inputs_);
-  RHTree->Branch("diPhoE",         &diPhoE_);
-  RHTree->Branch("diPhoPt",        &diPhoPt_);
+  tree->Branch("eventId",        &eventId_);
+  tree->Branch("runId",          &runId_);
+  tree->Branch("lumiId",         &lumiId_);
+  tree->Branch("m0",             &m0_);
+  //tree->Branch("nJet",           &nJet_);
+  tree->Branch("FC_inputs",      &vFC_inputs_);
+  tree->Branch("diPhoE",         &diPhoE_);
+  tree->Branch("diPhoPt",        &diPhoPt_);
 
 } // branchesEvtSel()
 

--- a/RecHitAnalyzer/plugins/RHAnalyzer_runEvtSel_jet.cc
+++ b/RecHitAnalyzer/plugins/RHAnalyzer_runEvtSel_jet.cc
@@ -1,109 +1,120 @@
 #include "MLAnalyzer/RecHitAnalyzer/interface/RecHitAnalyzer.h"
-/*
-#include "Geometry/CaloTopology/interface/CaloSubdetectorTopology.h"
-#include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
-#include "Geometry/CaloTopology/interface/CaloTopology.h"
-#include "Geometry/CaloTopology/interface/CaloSubdetectorTopology.h"
-*/
-using std::vector;
-// Run jet event selection ////////////////////////////////
 
-TH1D *h_jet_pT;
-TH1D *h_jet_E;
-TH1D *h_jet_eta;
-TH1D *h_jet_m0;
-TH1D *h_jet_nJet;
-float jet_eventId_;
-float jet_m0_;
-//const int nJets = 2;
+using std::vector;
+
+// Run jet event selection ////////////////////////////////
+// Only the jet seed finding is explicitly done here.
+// The explicit jet selection routines are contained in
+// the individual branchesEvtSel_jet_*() and runEvtSel_jet_*()
+
 const int search_window = 7;
-//const int image_padding = 14;
 const int image_padding = 12;
+unsigned int jet_runId_;
+unsigned int jet_lumiId_;
+unsigned long long jet_eventId_;
 vector<float> vJetSeed_iphi_;
 vector<float> vJetSeed_ieta_;
+//const std::string jetSelection = "dijet_gg_qq"; // TODO: put switch at cfg level
+const std::string jetSelection = "dijet";
 
 // Initialize branches _____________________________________________________//
 void RecHitAnalyzer::branchesEvtSel_jet ( TTree* tree, edm::Service<TFileService> &fs ) {
 
-  h_jet_pT    = fs->make<TH1D>("h_jet_pT"  , "p_{T};p_{T};Particles", 100,  0., 500.);
-  h_jet_E     = fs->make<TH1D>("h_jet_E"   , "E;E;Particles"        , 100,  0., 800.);
-  h_jet_eta   = fs->make<TH1D>("h_jet_eta" , "#eta;#eta;Particles"  , 100, -5., 5.);
-  h_jet_nJet  = fs->make<TH1D>("h_jet_nJet", "nJet;nJet;Events"     ,  10,  0., 10.);
-  h_jet_m0    = fs->make<TH1D>("h_jet_m0"  , "m0;m0;Events"         ,  60, 50., 110.);
+  tree->Branch("eventId",        &jet_eventId_);
+  tree->Branch("runId",          &jet_runId_);
+  tree->Branch("lumiId",         &jet_lumiId_);
+  tree->Branch("jetSeed_iphi",   &vJetSeed_iphi_);
+  tree->Branch("jetSeed_ieta",   &vJetSeed_ieta_);
 
-  RHTree->Branch("eventId",        &jet_eventId_);
-  RHTree->Branch("m0",             &jet_m0_);
-  RHTree->Branch("jetSeed_iphi",   &vJetSeed_iphi_);
-  RHTree->Branch("jetSeed_ieta",   &vJetSeed_ieta_);
+  // Fill branches in explicit jet selection
+  if ( jetSelection == "dijet_gg_qq" ) {
+    branchesEvtSel_jet_dijet_gg_qq( tree, fs );
+  } else {
+    branchesEvtSel_jet_dijet( tree, fs );
+  }
 
 } // branchesEvtSel_jet()
 
 // Run event selection ___________________________________________________________________//
 bool RecHitAnalyzer::runEvtSel_jet ( const edm::Event& iEvent, const edm::EventSetup& iSetup ) {
 
-  edm::Handle<HBHERecHitCollection> HBHERecHitsH_;
-  iEvent.getByToken( HBHERecHitCollectionT_, HBHERecHitsH_ );
+  vJetIdxs.clear(); // Each jet selection must fill this with good jet indices
+
+  // Run explicit jet selection
+  bool hasPassed;
+  if ( jetSelection == "dijet_gg_qq" ) {
+    hasPassed = runEvtSel_jet_dijet_gg_qq( iEvent, iSetup );
+  } else {
+    hasPassed = runEvtSel_jet_dijet( iEvent, iSetup );
+  }
+
+  if ( !hasPassed ) return false; 
+  std::sort(vJetIdxs.begin(), vJetIdxs.end());
+  if ( debug ) {
+    for ( int thisJetIdx : vJetIdxs ) {
+      std::cout << " index order:" << thisJetIdx << std::endl;
+    }
+  }
 
   edm::ESHandle<CaloGeometry> caloGeomH_;
   iSetup.get<CaloGeometryRecord>().get( caloGeomH_ );
   const CaloGeometry* caloGeom = caloGeomH_.product();
 
-  /*
-  edm::ESHandle<CaloTopology> caloTopoH_;
-  iSetup.get<CaloTopologyRecord>().get( caloTopoH_ );
-  const CaloTopology *caloTopo = caloTopoH_.product();
-  */
+  edm::Handle<HBHERecHitCollection> HBHERecHitsH_;
+  iEvent.getByToken( HBHERecHitCollectionT_, HBHERecHitsH_ );
 
   edm::Handle<reco::PFJetCollection> jets;
   iEvent.getByToken(jetCollectionT_, jets);
   if ( debug ) std::cout << " >> PFJetCol.size: " << jets->size() << std::endl;
 
+  float seedE;
+  int iphi_, ieta_, ietaAbs_;
 
   int nJet = 0;
-  vector<int>       jetIdx;
   vJetSeed_iphi_.clear();
   vJetSeed_ieta_.clear();
-
   // Loop over jets
-  for ( unsigned iJ(0); iJ != jets->size(); ++iJ ) {
+  for ( int thisJetIdx : vJetIdxs ) {
 
-    reco::PFJetRef iJet( jets, iJ );
-    if ( std::abs(iJet->pt()) < minJetPt_ ) continue;
-    if ( std::abs(iJet->eta()) > maxJetEta_) continue;
-    //if ( iJet->mass() < 50. || iJet->mass() > 110. ) continue;
-    if ( debug ) std::cout << " >> jet[" << iJ << "]Pt:" << iJet->pt() << " jetE:" << iJet->energy() << " jetM:" << iJet->mass() << std::endl;
+    reco::PFJetRef iJet( jets, thisJetIdx );
 
     // Get closest HBHE tower to jet position
     // This will not always be the most energetic deposit
     HcalDetId hId( spr::findDetIdHCAL( caloGeom, iJet->eta(), iJet->phi(), false ) );
     if ( hId.subdet() != HcalBarrel && hId.subdet() != HcalEndcap ) continue;
     HBHERecHitCollection::const_iterator iRHit( HBHERecHitsH_->find(hId) );
-    float seedE = ( iRHit == HBHERecHitsH_->end() ) ? 0. : iRHit->energy() ;
+    seedE = ( iRHit == HBHERecHitsH_->end() ) ? 0. : iRHit->energy() ;
     HcalDetId seedId = hId;
-    int iphi_, ieta_, ietaAbs_;
     if ( debug ) std::cout << " >> hId.ieta:" << hId.ieta() << " hId.iphi:" << hId.iphi() << " E:" << seedE << std::endl;
 
-    // Look for the highest HBHE tower deposit within a search window
+    // Look for the most energetic HBHE tower deposit within a search window
     for ( int ieta = 0; ieta < search_window; ieta++ ) {
-      ieta_   = hId.ieta() - (search_window/2)+ieta;
+
+      ieta_ = hId.ieta() - (search_window/2)+ieta;
+
       if ( std::abs(ieta_) > HBHE_IETA_MAX_HE-1 ) continue;
       if ( std::abs(ieta_) < HBHE_IETA_MIN_HB ) continue;
+
       HcalSubdetector subdet_ = std::abs(ieta_) > HBHE_IETA_MAX_HB ? HcalEndcap : HcalBarrel;
+
       for ( int iphi = 0; iphi < search_window; iphi++ ) {
-        iphi_   = hId.iphi() - (search_window/2)+iphi;
+
+        iphi_ = hId.iphi() - (search_window/2)+iphi;
+
+        // iphi should wrap around
         if ( iphi_ > HBHE_IPHI_MAX ) {
           iphi_ = iphi_-HBHE_IPHI_MAX;
         } else if ( iphi_ < HBHE_IPHI_MIN ) {
           iphi_ = HBHE_IPHI_MAX-abs(iphi_); 
         }
 
-        //if ( debug ) std::cout << " !! ieta_:" << ieta_ << " iphi_:" << iphi_ << std::endl;
+        // Skip non-existent and lower energy towers 
         HcalDetId hId_( subdet_, ieta_, iphi_, 1 );
         HBHERecHitCollection::const_iterator iRHit( HBHERecHitsH_->find(hId_) );
         if ( iRHit == HBHERecHitsH_->end() ) continue;
         if ( iRHit->energy() <= seedE ) continue;
-        //if ( iRHit->energy() <= seedE ) ;
         if ( debug ) std::cout << " !! hId.ieta:" << hId_.ieta() << " hId.iphi:" << hId_.iphi() << " E:" << iRHit->energy() << std::endl;
+
         seedE = iRHit->energy();
         seedId = hId_;
 
@@ -112,14 +123,6 @@ bool RecHitAnalyzer::runEvtSel_jet ( const edm::Event& iEvent, const edm::EventS
 
     // NOTE: HBHE iphi = 1 does not correspond to EB iphi = 1!
     // => Need to shift by 2 HBHE towers: HBHE::iphi: [1,...,71,72]->[3,4,...,71,72,1,2]
-    //float eta, phi;
-    //GlobalPoint pos;
-    //EBDetId ebId( 1, 1 );
-    //pos = caloGeom->getPosition( ebId );
-    //eta = pos.eta();
-    //phi = pos.phi();
-    //HcalDetId hcalebId( spr::findDetIdHCAL( caloGeom, eta, phi, false ) );
-    //seedId = hcalebId; 
     iphi_  = seedId.iphi() + 2; // shift
     iphi_  = iphi_ > HBHE_IPHI_MAX ? iphi_-HBHE_IPHI_MAX : iphi_; // wrap-around
     iphi_  = iphi_ - 1; // make histogram-friendly
@@ -129,61 +132,31 @@ bool RecHitAnalyzer::runEvtSel_jet ( const edm::Event& iEvent, const edm::EventS
 
     // If the seed is too close to the edge of HE, discard event
     // Required to keep the seed at the image center
-    if ( HBHE_IETA_MAX_HE-1 - ietaAbs_ < image_padding ) {
+    if ( HBHE_IETA_MAX_HE-1 - ietaAbs_ < image_padding ) { 
       if ( debug ) std::cout << " Fail HE edge cut " << std::endl;
       continue;
     }
 
-
+    // Save position of most energetic HBHE tower
+    // in EB-aligned coordinates
     if ( debug ) std::cout << " !! ieta_:" << ieta_ << " iphi_:" << iphi_ << " ietaAbs_:" << ietaAbs_ << " E:" << seedE << std::endl;
-    
-    jetIdx        .push_back(iJ);
-    vJetSeed_iphi_.push_back(iphi_);
-    vJetSeed_ieta_.push_back(ieta_);
-
+    vJetSeed_iphi_.push_back( iphi_ );
+    vJetSeed_ieta_.push_back( ieta_ );
     nJet++;
-    if ( (nJets_ > 0) && (nJet >= nJets_) ) break;
 
-    // Doesnt seem to work:
-    //const CaloSubdetectorTopology* topo = caloTopo->getSubdetectorTopology( hId );
-    //const CaloSubdetectorTopology* topo = caloTopo->getSubdetectorTopology( DetId::Hcal, hId.subdet() );
-    //std::vector<DetId> hId_5x5 = topo->getWindow( hId, 5, 5 );
-    //std::cout << "window size:" << hId_5x5.size() << std::endl;
-    //std::cout << " pT:" << iJet->pt() << " eta:" << iJet->eta() << " phi: " << iJet->phi() << " E:" << iJet->energy() << std::endl;
-  } // jets
+  } // good jets 
+  
+  if ( nJet != nJets_ ) return false;
+  if ( debug ) std::cout << " >> analyze: passed" << std::endl;
 
-  h_jet_nJet->Fill( nJet );
-  if ( debug ) {
-    for(int thisJetIdx : jetIdx)
-      std::cout << " >> jetIdx:" << thisJetIdx << std::endl;
-  }
-
-  if ( (nJets_ > 0) && (nJet != nJets_) ){
-    if ( debug ) std::cout << " Fail jet multiplicity:  " << nJet << " != " << nJets_ << std::endl;
-    return false;
-  }
-
-  if ( jetIdx.size() == 0){
-    if ( debug ) std::cout << " No passing jets...  " << std::endl;
-    return false;
-  }
-
-
-  // Plot kinematics
-  for(int thisJetIdx : jetIdx){
-    reco::PFJetRef thisJet( jets, thisJetIdx );
-    if ( debug ) std::cout << " >> Jet[" << thisJetIdx << "] Pt:" << thisJet->pt() << std::endl;
-    h_jet_pT->Fill( std::abs(thisJet->pt()) );
-    h_jet_eta->Fill( thisJet->eta() );
-    h_jet_E->Fill( thisJet->energy() );
-    h_jet_m0->Fill( thisJet->mass() );
-
-  }
-
-  // Write out event ID
-  reco::PFJetRef leadJet( jets, jetIdx.at(0) );
-  jet_m0_ = leadJet->mass();
   jet_eventId_ = iEvent.id().event();
+  jet_runId_ = iEvent.id().run();
+  jet_lumiId_ = iEvent.id().luminosityBlock();
+  if ( jetSelection == "dijet_gg_qq" ) {
+    fillEvtSel_jet_dijet_gg_qq( iEvent, iSetup );
+  } else {
+    fillEvtSel_jet_dijet( iEvent, iSetup );
+  }
 
   return true;
 

--- a/RecHitAnalyzer/plugins/RHAnalyzer_runEvtSel_jet_dijet.cc
+++ b/RecHitAnalyzer/plugins/RHAnalyzer_runEvtSel_jet_dijet.cc
@@ -1,0 +1,98 @@
+#include "MLAnalyzer/RecHitAnalyzer/interface/RecHitAnalyzer.h"
+
+using std::vector;
+
+TH1D *h_dijet_jet_pT;
+TH1D *h_dijet_jet_E;
+TH1D *h_dijet_jet_eta;
+TH1D *h_dijet_jet_m0;
+TH1D *h_dijet_jet_nJet;
+vector<float> vDijet_jet_pT_;
+vector<float> vDijet_jet_m0_;
+vector<float> vDijet_jet_eta_;
+
+// Initialize branches _____________________________________________________//
+void RecHitAnalyzer::branchesEvtSel_jet_dijet( TTree* tree, edm::Service<TFileService> &fs ) {
+
+  h_dijet_jet_pT    = fs->make<TH1D>("h_jet_pT"  , "p_{T};p_{T};Particles", 100,  0., 500.);
+  h_dijet_jet_E     = fs->make<TH1D>("h_jet_E"   , "E;E;Particles"        , 100,  0., 800.);
+  h_dijet_jet_eta   = fs->make<TH1D>("h_jet_eta" , "#eta;#eta;Particles"  , 100, -5., 5.);
+  h_dijet_jet_nJet  = fs->make<TH1D>("h_jet_nJet", "nJet;nJet;Events"     ,  10,  0., 10.);
+  h_dijet_jet_m0    = fs->make<TH1D>("h_jet_m0"  , "m0;m0;Events"         , 100,  0., 100.);
+
+  tree->Branch("jetPt",  &vDijet_jet_pT_);
+  tree->Branch("jetM",   &vDijet_jet_m0_);
+  tree->Branch("jetEta", &vDijet_jet_eta_);
+
+} // branchesEvtSel_jet_dijet()
+
+// Run jet selection _____________________________________________________//
+bool RecHitAnalyzer::runEvtSel_jet_dijet( const edm::Event& iEvent, const edm::EventSetup& iSetup )
+{
+
+  edm::Handle<reco::PFJetCollection> jets;
+  iEvent.getByToken(jetCollectionT_, jets);
+
+  vJetIdxs.clear();
+  vDijet_jet_pT_.clear();
+  vDijet_jet_m0_.clear();
+  vDijet_jet_eta_.clear();
+
+  int nJet = 0;
+  // Loop over jets
+  for ( unsigned iJ(0); iJ != jets->size(); ++iJ ) {
+
+    reco::PFJetRef iJet( jets, iJ );
+    if ( std::abs(iJet->pt()) < minJetPt_ ) continue;
+    if ( std::abs(iJet->eta()) > maxJetEta_) continue;
+    if ( debug ) std::cout << " >> jet[" << iJ << "]Pt:" << iJet->pt() << " jetE:" << iJet->energy() << " jetM:" << iJet->mass() << std::endl;
+
+    vJetIdxs.push_back(iJ);
+
+    nJet++;
+    if ( (nJets_ > 0) && (nJet >= nJets_) ) break;
+
+  } // jets
+
+
+  if ( debug ) {
+    for(int thisJetIdx : vJetIdxs)
+      std::cout << " >> vJetIdxs:" << thisJetIdx << std::endl;
+  }
+
+  if ( (nJets_ > 0) && (nJet != nJets_) ){
+    if ( debug ) std::cout << " Fail jet multiplicity:  " << nJet << " != " << nJets_ << std::endl;
+    return false;
+  }
+
+  if ( vJetIdxs.size() == 0){
+    if ( debug ) std::cout << " No passing jets...  " << std::endl;
+    return false;
+  }
+
+  if ( debug ) std::cout << " >> has_jet_dijet: passed" << std::endl;
+  return true;
+
+} // runEvtSel_jet_dijet() 
+
+// Fill branches and histograms _____________________________________________________//
+void RecHitAnalyzer::fillEvtSel_jet_dijet( const edm::Event& iEvent, const edm::EventSetup& iSetup ) {
+
+  edm::Handle<reco::PFJetCollection> jets;
+  iEvent.getByToken(jetCollectionT_, jets);
+
+  h_dijet_jet_nJet->Fill( vJetIdxs.size() );
+  // Fill branches and histograms 
+  for(int thisJetIdx : vJetIdxs){
+    reco::PFJetRef thisJet( jets, thisJetIdx );
+    if ( debug ) std::cout << " >> Jet[" << thisJetIdx << "] Pt:" << thisJet->pt() << std::endl;
+    h_dijet_jet_pT->Fill( std::abs(thisJet->pt()) );
+    h_dijet_jet_E->Fill( thisJet->energy() );
+    h_dijet_jet_m0->Fill( thisJet->mass() );
+    h_dijet_jet_eta->Fill( thisJet->eta() );
+    vDijet_jet_pT_.push_back( std::abs(thisJet->pt()) );
+    vDijet_jet_m0_.push_back( thisJet->mass() );
+    vDijet_jet_eta_.push_back( thisJet->eta() );
+  }
+
+} // fillEvtSel_jet_dijet()

--- a/RecHitAnalyzer/plugins/RHAnalyzer_runEvtSel_jet_dijet_gg_qq.cc
+++ b/RecHitAnalyzer/plugins/RHAnalyzer_runEvtSel_jet_dijet_gg_qq.cc
@@ -1,0 +1,179 @@
+#include "MLAnalyzer/RecHitAnalyzer/interface/RecHitAnalyzer.h"
+
+using std::vector;
+
+const unsigned nJets = 2; //TODO: use cfg level nJets_
+TH1D *h_ggqq_jet_pT;
+TH1D *h_ggqq_jet_E;
+TH1D *h_ggqq_jet_eta;
+TH1D *h_ggqq_jet_m0;
+TH1D *h_ggqq_jet_nJet;
+TH1D *h_nGG;
+TH1D *h_nQQ;
+vector<float> v_ggqq_jet_m0_;
+vector<float> v_ggqq_jet_pt_;
+vector<float> v_ggqq_jetIsQuark_;
+vector<float> v_ggqq_jetPdgIds_;
+
+vector<float> v_ggqq_subJetE_[nJets];
+vector<float> v_ggqq_subJetPx_[nJets];
+vector<float> v_ggqq_subJetPy_[nJets];
+vector<float> v_ggqq_subJetPz_[nJets];
+
+// Initialize branches _____________________________________________________//
+void RecHitAnalyzer::branchesEvtSel_jet_dijet_gg_qq ( TTree* tree, edm::Service<TFileService> &fs ) {
+
+  h_ggqq_jet_pT    = fs->make<TH1D>("h_jet_pT"  , "p_{T};p_{T};Particles", 100,  0., 500.);
+  h_ggqq_jet_E     = fs->make<TH1D>("h_jet_E"   , "E;E;Particles"        , 100,  0., 800.);
+  h_ggqq_jet_eta   = fs->make<TH1D>("h_jet_eta" , "#eta;#eta;Particles"  , 100, -5., 5.);
+  h_ggqq_jet_nJet  = fs->make<TH1D>("h_jet_nJet", "nJet;nJet;Events"     ,  10,  0., 10.);
+  h_ggqq_jet_m0    = fs->make<TH1D>("h_jet_m0"  , "m0;m0;Events"         , 100,  0., 100.);
+  h_nGG       = fs->make<TH1D>("h_nGG"     , "nGG;nGG;Events"       ,   3,  0.,   3.);
+  h_nQQ       = fs->make<TH1D>("h_nQQ"     , "nQQ;nQQ;Events"       ,   3,  0.,   3.);
+
+  tree->Branch("jetM",       &v_ggqq_jet_m0_);
+  tree->Branch("jetPt",      &v_ggqq_jet_pt_);
+  tree->Branch("jetIsQuark", &v_ggqq_jetIsQuark_);
+  tree->Branch("jetPdgIds",  &v_ggqq_jetPdgIds_);
+
+  char hname[50];
+  for ( unsigned iJ = 0; iJ != nJets; iJ++ ) {
+    sprintf(hname, "subJet%d_E", iJ);
+    tree->Branch(hname,            &v_ggqq_subJetE_[iJ]);
+    sprintf(hname, "subJet%d_Px", iJ);
+    tree->Branch(hname,            &v_ggqq_subJetPx_[iJ]);
+    sprintf(hname, "subJet%d_Py", iJ);
+    tree->Branch(hname,            &v_ggqq_subJetPy_[iJ]);
+    sprintf(hname, "subJet%d_Pz", iJ);
+    tree->Branch(hname,            &v_ggqq_subJetPz_[iJ]);
+  }
+
+} // branchesEvtSel_jet_dijet_gg_qq()
+
+// Run jet selection _____________________________________________________//
+bool RecHitAnalyzer::runEvtSel_jet_dijet_gg_qq( const edm::Event& iEvent, const edm::EventSetup& iSetup )
+{
+
+  edm::Handle<reco::GenParticleCollection> genParticles;
+  iEvent.getByToken( genParticleCollectionT_, genParticles );
+
+  edm::Handle<reco::PFJetCollection> jets;
+  iEvent.getByToken(jetCollectionT_, jets);
+  float dR;
+
+  vJetIdxs.clear();
+  v_ggqq_jetPdgIds_.clear();
+  /*
+  edm::Handle<reco::GenJetCollection> genJets;
+  iEvent.getByToken(genJetCollectionT_, genJets);
+  std::vector<float> v_ggqq_jetFakePhoIdxs;
+  */
+
+  unsigned nGG = 0;
+  unsigned nQQ = 0;
+
+  if ( debug ) std::cout << " >>>>>>>>>>>>>>>>>>>> evt:" << std::endl;
+  for (reco::GenParticleCollection::const_iterator iGen = genParticles->begin();
+      iGen != genParticles->end();
+      ++iGen) {
+
+    if ( iGen->numberOfMothers() != 2 ) continue;
+    //if ( iGen->status() != 3 ) continue; // pythia6: 3 = hard scatter particle
+    if ( iGen->status() != 23 ) continue; // pythia8: 23 = outgoing particle from hard scatter
+    if ( debug ) std::cout << " >> id:" << iGen->pdgId() << " status:" << iGen->status() << " nDaught:" << iGen->numberOfDaughters() << " pt:"<< iGen->pt() << " eta:" <<iGen->eta() << " phi:" <<iGen->phi() << " nMoms:" <<iGen->numberOfMothers()<< std::endl;
+
+    // Loop over jets
+    for ( unsigned iJ(0); iJ != jets->size(); ++iJ ) {
+      //if ( debug ) std::cout << " >>>>>> jet[" << iJ << "]" << std::endl;
+      reco::PFJetRef iJet( jets, iJ );
+      if ( std::abs(iJet->pt())  < minJetPt_ ) continue;
+      if ( std::abs(iJet->eta()) > maxJetEta_ ) continue;
+      dR = reco::deltaR( iJet->eta(),iJet->phi(), iGen->eta(),iGen->phi() );
+      if ( debug ) {
+        std::cout << " >>>>>> jet[" << iJ << "] Pt:" << iJet->pt() << " jetEta:" << iJet->eta() << " jetPhi:" << iJet->phi()
+        << " dR:" << dR << std::endl;
+      }
+      if ( dR > 0.4 ) continue;
+      vJetIdxs.push_back( iJ );
+      v_ggqq_jetPdgIds_.push_back( std::abs(iGen->pdgId()) );
+      if ( debug ) {
+        std::cout << " >>>>>> DR matched: jet[" << iJ << "] pdgId:" << std::abs(iGen->pdgId()) << std::endl;
+      }
+      break;
+    } // reco jets
+
+  } // gen particles
+
+  // Check jet multiplicity
+  if ( vJetIdxs.size() != nJets ) return false;
+
+  // Check jet identities
+  for ( unsigned iJ(0); iJ != nJets; ++iJ ) {
+    if ( v_ggqq_jetPdgIds_[iJ] < 4 ) nQQ++;
+    else if ( v_ggqq_jetPdgIds_[iJ] == 21 ) nGG++;
+  }
+  if ( vJetIdxs[0] == vJetIdxs[1] ) return false; // protect against double matching: only valid for nJets==2
+  if ( nQQ+nGG != nJets ) return false; // require dijet
+  if ( nQQ != nJets && nGG != nJets ) return false; // require gg or qq final state
+  //if ( nQQ != 1 && nGG != 1 ) return false; // require qg final state
+
+  if ( debug ) std::cout << " >> has_jet_dijet_gg_qq: passed" << std::endl;
+  return true;
+
+} // runEvtSel_jet_dijet_gg_qq()
+
+// Fill branches and histograms _____________________________________________________//
+void RecHitAnalyzer::fillEvtSel_jet_dijet_gg_qq ( const edm::Event& iEvent, const edm::EventSetup& iSetup ) {
+
+  edm::Handle<reco::PFJetCollection> jets;
+  iEvent.getByToken(jetCollectionT_, jets);
+
+  h_ggqq_jet_nJet->Fill( vJetIdxs.size() );
+
+  unsigned nGG = 0;
+  unsigned nQQ = 0;
+  v_ggqq_jet_pt_.clear();
+  v_ggqq_jet_m0_.clear();
+  v_ggqq_jetIsQuark_.clear();
+  for ( unsigned iJ(0); iJ != vJetIdxs.size(); ++iJ ) {
+
+    reco::PFJetRef iJet( jets, vJetIdxs[iJ] );
+
+    // Fill histograms 
+    h_ggqq_jet_pT->Fill( std::abs(iJet->pt()) );
+    h_ggqq_jet_eta->Fill( iJet->eta() );
+    h_ggqq_jet_E->Fill( iJet->energy() );
+    h_ggqq_jet_m0->Fill( iJet->mass() );
+
+    // Fill branches 
+    v_ggqq_jet_pt_.push_back( iJet->pt() );
+    v_ggqq_jet_m0_.push_back( iJet->mass() );
+    if ( v_ggqq_jetPdgIds_[iJ] < 4 ) {
+      v_ggqq_jetIsQuark_.push_back( true );
+      nQQ++;
+    } else {
+      v_ggqq_jetIsQuark_.push_back( false );
+      nGG++;
+    }
+
+    // Get jet constituents
+    v_ggqq_subJetE_[iJ].clear();
+    v_ggqq_subJetPx_[iJ].clear();
+    v_ggqq_subJetPy_[iJ].clear();
+    v_ggqq_subJetPz_[iJ].clear();
+    //std::vector<reco::PFCandidatePtr> jetConstituents = iJet->getPFConstituents();
+    unsigned int nConstituents = iJet->getPFConstituents().size();
+    for ( unsigned int j = 0; j < nConstituents; j++ ) {
+      const reco::PFCandidatePtr subJet = iJet->getPFConstituent( j );
+      std::cout << " >> " << j << ": E:" << subJet->energy() << " px:" << subJet->px() << " py:" << subJet->py() << " pz:" << subJet->pz() << std::endl;
+      v_ggqq_subJetE_[iJ].push_back( subJet->energy() );
+      v_ggqq_subJetPx_[iJ].push_back( subJet->px() );
+      v_ggqq_subJetPy_[iJ].push_back( subJet->py() );
+      v_ggqq_subJetPz_[iJ].push_back( subJet->pz() );
+    }
+  }
+  h_nGG->Fill( nGG );
+  h_nQQ->Fill( nQQ );
+
+
+} // fillEvtSel_jet_dijet_gg_qq()

--- a/RecHitAnalyzer/plugins/RecHitAnalyzer.cc
+++ b/RecHitAnalyzer/plugins/RecHitAnalyzer.cc
@@ -2,12 +2,13 @@
 //
 // Package:    MLAnalyzer/RecHitAnalyzer
 // Class:      RecHitAnalyzer
-// 
+//
 //
 // Original Author:  Michael Andrews
 //         Created:  Sat, 14 Jan 2017 17:45:54 GMT
 //
 //
+
 #include "MLAnalyzer/RecHitAnalyzer/interface/RecHitAnalyzer.h"
 
 //
@@ -15,36 +16,35 @@
 //
 RecHitAnalyzer::RecHitAnalyzer(const edm::ParameterSet& iConfig)
 {
-  //EBRecHitCollectionT_ = consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("EBRecHitCollection"));
-  EBRecHitCollectionT_ = consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("reducedEBRecHitCollection"));
-  //EBDigiCollectionT_ = consumes<EBDigiCollection>(iConfig.getParameter<edm::InputTag>("selectedEBDigiCollection"));
-  //EBDigiCollectionT_ = consumes<EBDigiCollection>(iConfig.getParameter<edm::InputTag>("EBDigiCollection"));
-  EERecHitCollectionT_ = consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("reducedEERecHitCollection"));
-  //EERecHitCollectionT_ = consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("EERecHitCollection"));
-  HBHERecHitCollectionT_ = consumes<HBHERecHitCollection>(iConfig.getParameter<edm::InputTag>("reducedHBHERecHitCollection"));
-  TRKRecHitCollectionT_  = consumes<TrackingRecHitCollection>(iConfig.getParameter<edm::InputTag>("trackRecHitCollection"));
+  //EBRecHitCollectionT_    = consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("EBRecHitCollection"));
+  EBRecHitCollectionT_    = consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("reducedEBRecHitCollection"));
+  //EBDigiCollectionT_      = consumes<EBDigiCollection>(iConfig.getParameter<edm::InputTag>("selectedEBDigiCollection"));
+  //EBDigiCollectionT_      = consumes<EBDigiCollection>(iConfig.getParameter<edm::InputTag>("EBDigiCollection"));
+  EERecHitCollectionT_    = consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("reducedEERecHitCollection"));
+  //EERecHitCollectionT_    = consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("EERecHitCollection"));
+  HBHERecHitCollectionT_  = consumes<HBHERecHitCollection>(iConfig.getParameter<edm::InputTag>("reducedHBHERecHitCollection"));
+  TRKRecHitCollectionT_   = consumes<TrackingRecHitCollection>(iConfig.getParameter<edm::InputTag>("trackRecHitCollection"));
 
   genParticleCollectionT_ = consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("genParticleCollection"));
-  photonCollectionT_ = consumes<reco::PhotonCollection>(iConfig.getParameter<edm::InputTag>("gedPhotonCollection"));
-  jetCollectionT_ = consumes<reco::PFJetCollection>(iConfig.getParameter<edm::InputTag>("ak4PFJetCollection"));
-  genJetCollectionT_ = consumes<reco::GenJetCollection>(iConfig.getParameter<edm::InputTag>("genJetCollection"));
-  trackCollectionT_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("trackCollection"));
-  pfCollectionT_ = consumes<PFCollection>(iConfig.getParameter<edm::InputTag>("pfCollection"));
-
+  photonCollectionT_      = consumes<reco::PhotonCollection>(iConfig.getParameter<edm::InputTag>("gedPhotonCollection"));
+  jetCollectionT_         = consumes<reco::PFJetCollection>(iConfig.getParameter<edm::InputTag>("ak4PFJetCollection"));
+  genJetCollectionT_      = consumes<reco::GenJetCollection>(iConfig.getParameter<edm::InputTag>("genJetCollection"));
+  trackCollectionT_       = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("trackCollection"));
+  pfCollectionT_          = consumes<PFCollection>(iConfig.getParameter<edm::InputTag>("pfCollection"));
 
   //johnda add configuration
-  minJetPt_ = iConfig.getParameter<double>("minJetPt");
+  mode_      = iConfig.getParameter<std::string>("mode");
+  minJetPt_  = iConfig.getParameter<double>("minJetPt");
   maxJetEta_ = iConfig.getParameter<double>("maxJetEta");
-  mode_ = iConfig.getParameter<std::string>("mode");
-  std::cout << " Mode set to " << mode_ << std::endl;
-  if( mode_ == "JetLevel"){
-    doJets_    = true;
+  std::cout << " >> Mode set to " << mode_ << std::endl;
+  if ( mode_ == "JetLevel" ) {
+    doJets_ = true;
     nJets_ = iConfig.getParameter<int>("nJets");
-    std::cout << " \t nJets set to " << nJets_ << std::endl;
-  }else if (mode_ == "EventLevel"){
+    std::cout << "\t>> nJets set to " << nJets_ << std::endl;
+  } else if ( mode_ == "EventLevel" ) {
     doJets_ = false;
   } else {
-    std::cout << " Assuming EventLevel Config. " << std::endl;
+    std::cout << " >> Assuming EventLevel Config. " << std::endl;
     doJets_ = false;
   }
 
@@ -59,12 +59,11 @@ RecHitAnalyzer::RecHitAnalyzer(const edm::ParameterSet& iConfig)
 
   // These will be use to create the actual images
   RHTree = fs->make<TTree>("RHTree", "RecHit tree");
-  if(doJets_){
+  if ( doJets_ ) {
     branchesEvtSel_jet( RHTree, fs );
-  }else{
+  } else {
     branchesEvtSel( RHTree, fs );
   }
-
   branchesEB           ( RHTree, fs );
   branchesEE           ( RHTree, fs );
   branchesHBHE         ( RHTree, fs );
@@ -75,7 +74,6 @@ RecHitAnalyzer::RecHitAnalyzer(const edm::ParameterSet& iConfig)
   branchesTracksAtECALstitched( RHTree, fs);
   branchesPFCandsAtEBEE(RHTree, fs);
   branchesPFCandsAtECALstitched( RHTree, fs);
-
   //branchesTRKlayersAtEBEE(RHTree, fs);
   //branchesTRKlayersAtECAL(RHTree, fs);
   //branchesTRKvolumeAtEBEE(RHTree, fs);
@@ -101,19 +99,22 @@ void
 RecHitAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
 
+  nTotal++;
   using namespace edm;
 
   // ----- Apply event selection cuts ----- //
 
   bool passedSelection = false;
-  if(doJets_){
+  if ( doJets_ ) {
     passedSelection = runEvtSel_jet( iEvent, iSetup );
-  }else{
+  } else {
     passedSelection = runEvtSel( iEvent, iSetup );
   }
 
-
-  if ( !passedSelection ) return;
+  if ( !passedSelection ) {
+    h_sel->Fill( 0. );;
+    return;
+  }
 
   fillEB( iEvent, iSetup );
   fillEE( iEvent, iSetup );
@@ -136,6 +137,7 @@ RecHitAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   // Fill RHTree
   RHTree->Fill();
   h_sel->Fill( 1. );
+  nPassed++;
 
 } // analyze()
 
@@ -144,12 +146,15 @@ RecHitAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 void 
 RecHitAnalyzer::beginJob()
 {
+  nTotal = 0;
+  nPassed = 0;
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
 void 
 RecHitAnalyzer::endJob() 
 {
+  std::cout << " selected: " << nPassed << "/" << nTotal << std::endl;
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
@@ -178,14 +183,14 @@ RecHitAnalyzer::getPFCand(edm::Handle<PFCollection> pfCands, float eta, float ph
         iPFC != pfCands->end(); ++iPFC ) {
 
     const reco::Track* thisTrk = iPFC->bestTrack();
-    if(!thisTrk) continue;
+    if ( !thisTrk ) continue;
 
     float thisdR = reco::deltaR( eta, phi, thisTrk->eta(), thisTrk->phi() );
-    if(debug) std::cout << "\tthisdR: " << thisdR << " " << thisTrk->pt() << " " << iPFC->particleId() << std::endl;
+    if (debug) std::cout << "\tthisdR: " << thisdR << " " << thisTrk->pt() << " " << iPFC->particleId() << std::endl;
 
     const reco::PFCandidate& thisPFCand = (*iPFC);
       
-    if( (thisdR < 0.01) && (thisdR <minDr)){
+    if ( (thisdR < 0.01) && (thisdR <minDr) ) {
       minDr    = thisdR; 
       minDRCand = &thisPFCand;
     }
@@ -193,7 +198,6 @@ RecHitAnalyzer::getPFCand(edm::Handle<PFCollection> pfCands, float eta, float ph
 
   return minDRCand;  
 }
-
 
 const reco::Track*
 RecHitAnalyzer::getTrackCand(edm::Handle<reco::TrackCollection> trackCands, float eta, float phi, float& minDr, bool debug ) {
@@ -207,11 +211,11 @@ RecHitAnalyzer::getTrackCand(edm::Handle<reco::TrackCollection> trackCands, floa
     if ( !(iTk->quality(tkQt_)) ) continue;  
 
     float thisdR = reco::deltaR( eta, phi, iTk->eta(),iTk->phi() );
-    if(debug) std::cout << "\tthisdR: " << thisdR << " " << iTk->pt() << std::endl;
+    if (debug) std::cout << "\tthisdR: " << thisdR << " " << iTk->pt() << std::endl;
 
     const reco::Track& thisTrackCand = (*iTk);
       
-    if( (thisdR < 0.01) && (thisdR <minDr)){
+    if ( (thisdR < 0.01) && (thisdR <minDr) ) {
       minDr    = thisdR; 
       minDRCand = &thisTrackCand;
     }
@@ -219,8 +223,6 @@ RecHitAnalyzer::getTrackCand(edm::Handle<reco::TrackCollection> trackCands, floa
 
   return minDRCand;  
 }
-
-
 
 /*
 //____ Fill FC diphoton variables _____//

--- a/RecHitAnalyzer/python/CfiFile_cfi.py
+++ b/RecHitAnalyzer/python/CfiFile_cfi.py
@@ -1,5 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-demo = cms.EDAnalyzer('RecHitAnalyzer'
-     ,tracks = cms.untracked.InputTag('ctfWithMaterialTracks')
-)

--- a/RecHitAnalyzer/python/ConfFile_cfg.py
+++ b/RecHitAnalyzer/python/ConfFile_cfg.py
@@ -1,5 +1,4 @@
 import FWCore.ParameterSet.Config as cms
-
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 options = VarParsing.VarParsing('analysis')
@@ -8,12 +7,16 @@ options.register('skipEvents',
     mult=VarParsing.VarParsing.multiplicity.singleton,
     mytype=VarParsing.VarParsing.varType.int,
     info = "skipEvents")
+# TODO: put this option in cmsRun scripts
+options.register('processMode', 
+    default='JetLevel', 
+    mult=VarParsing.VarParsing.multiplicity.singleton,
+    mytype=VarParsing.VarParsing.varType.string,
+    info = "process mode: JetLevel or EventLevel")
 options.parseArguments()
 
 process = cms.Process("FEVTAnalyzer")
-
 process.load("FWCore.MessageService.MessageLogger_cfi")
-#process.load("DQM.Integration.config.FrontierCondition_GT_Offline_cfi")
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 #process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
@@ -21,58 +24,30 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 #process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi");
 #process.load("Geometry.CaloEventSetup.CaloGeometry_cfi");
 #process.load("Geometry.CaloEventSetup.CaloTopology_cfi");
+process.GlobalTag.globaltag = cms.string('80X_dataRun2_HLT_v12')
+process.es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')
 
 process.maxEvents = cms.untracked.PSet( 
-    #input = cms.untracked.int32(1) 
     input = cms.untracked.int32(options.maxEvents) 
     )
 
-print " >> Loaded",len(options.inputFiles),"input files from list."
 process.source = cms.Source("PoolSource",
-    # replace 'myfile.root' with the source file you want to use
     fileNames = cms.untracked.vstring(
-      #'file:myfile.root'
-      #'file:pickevents.root'
-      #'file:pickeventsRECO.root'
-      #'file:step3.root'
-      #'file:SinglePhotonPt50_FEVTDEBUG.root'
-      #'file:SingleElectronPt50_FEVTDEBUG.root'
-      #'file:/eos/uscms/store/user/mba2012/FEVTDEBUG/H125GGgluonfusion_13TeV_TuneCUETP8M1_FEVTDEBUG/*/*/step_full_*.root'
       options.inputFiles
       )
     , skipEvents = cms.untracked.uint32(options.skipEvents)
     )
+print " >> Loaded",len(options.inputFiles),"input files from list."
 
-process.GlobalTag.globaltag = cms.string('80X_dataRun2_HLT_v12')
-process.es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')
-
-process.fevt = cms.EDAnalyzer('RecHitAnalyzer'
-    #, tracks = cms.untracked.InputTag('ctfWithMaterialTracks')
-    #, EBRecHitCollection = cms.InputTag('ecalRecHit:EcalRecHitsEB')
-    , reducedEBRecHitCollection = cms.InputTag('reducedEcalRecHitsEB')
-    #, EERecHitCollection = cms.InputTag('ecalRecHit:EcalRecHitsEE')
-    , reducedEERecHitCollection = cms.InputTag('reducedEcalRecHitsEE')
-    #, EBDigiCollection = cms.InputTag('simEcalDigis:ebDigis')
-    #, selectedEBDigiCollection = cms.InputTag('selectDigi:selectedEcalEBDigiCollection')
-    , reducedHBHERecHitCollection = cms.InputTag('reducedHcalRecHits:hbhereco')
-    , genParticleCollection = cms.InputTag('genParticles')
-    , gedPhotonCollection = cms.InputTag('gedPhotons')
-    , ak4PFJetCollection = cms.InputTag('ak4PFJets')
-    , genJetCollection = cms.InputTag('ak4GenJets')
-    , trackRecHitCollection = cms.InputTag('generalTracks')
-    , trackCollection = cms.InputTag("generalTracks")
-    , pfCollection = cms.InputTag("particleFlow")
-    , mode = cms.string("JetLevel") 
-    , nJets = cms.int32(2) 
-    , minJetPt = cms.double(20.) 
-    , maxJetEta = cms.double(2.4) 
-    )
+process.load("MLAnalyzer.RecHitAnalyzer.RHAnalyzer_cfi")
+process.fevt.mode = cms.string(options.processMode)
+#process.fevt.mode = cms.string("JetLevel") # for when using crab
+#process.fevt.mode = cms.string("EventLevel") # for when using crab
+print " >> Processing as:",(process.fevt.mode)
 
 process.TFileService = cms.Service("TFileService",
-    #fileName = cms.string('histo.root')
     fileName = cms.string(options.outputFile)
     )
 
 #process.SimpleMemoryCheck = cms.Service( "SimpleMemoryCheck", ignoreTotal = cms.untracked.int32(1) )
-
 process.p = cms.Path(process.fevt)

--- a/RecHitAnalyzer/python/RHAnalyzer_cfi.py
+++ b/RecHitAnalyzer/python/RHAnalyzer_cfi.py
@@ -1,0 +1,25 @@
+import FWCore.ParameterSet.Config as cms 
+
+fevt = cms.EDAnalyzer('RecHitAnalyzer'
+    #, tracks = cms.untracked.InputTag('ctfWithMaterialTracks')
+    #, EBRecHitCollection = cms.InputTag('ecalRecHit:EcalRecHitsEB')
+    , reducedEBRecHitCollection = cms.InputTag('reducedEcalRecHitsEB')
+    #, EERecHitCollection = cms.InputTag('ecalRecHit:EcalRecHitsEE')
+    , reducedEERecHitCollection = cms.InputTag('reducedEcalRecHitsEE')
+    #, EBDigiCollection = cms.InputTag('simEcalDigis:ebDigis')
+    #, selectedEBDigiCollection = cms.InputTag('selectDigi:selectedEcalEBDigiCollection')
+    , reducedHBHERecHitCollection = cms.InputTag('reducedHcalRecHits:hbhereco')
+    , genParticleCollection = cms.InputTag('genParticles')
+    , gedPhotonCollection = cms.InputTag('gedPhotons')
+    , ak4PFJetCollection = cms.InputTag('ak4PFJets')
+    , genJetCollection = cms.InputTag('ak4GenJets')
+    , trackRecHitCollection = cms.InputTag('generalTracks')
+    , trackCollection = cms.InputTag("generalTracks")
+    , pfCollection = cms.InputTag("particleFlow")
+    , mode = cms.string("JetLevel")
+
+    # Jet level cfg
+    , nJets = cms.int32(2)
+    , minJetPt = cms.double(20.)
+    , maxJetEta = cms.double(2.4)
+    )

--- a/convert_Tree2Dask_ECAL+HCAL+Tracksv3+jets.py
+++ b/convert_Tree2Dask_ECAL+HCAL+Tracksv3+jets.py
@@ -4,6 +4,7 @@ from root_numpy import tree2array
 from dask.delayed import delayed
 import dask.array as da
 from skimage.measure import block_reduce
+import os
 
 #eosDir='/eos/uscms/store/user/mba2012/IMGs'
 #eosDir='~/work/MLHEP/CMSSW_8_0_26_patch1/src/ggAnalysis/ggNtuplizer/test'
@@ -38,20 +39,15 @@ def load_X(tree, start_, stop_, branches_, readouts, scale):
 def load_single(tree, start_, stop_, branches_):
     X = tree2array(tree, start=start_, stop=stop_, branches=branches_)
     X = np.array([x[0] for x in X])
-
     return X
 
 @delayed
-def load_vector(tree, start_, stop_, branches_):
+def load_vector(tree, start_, stop_, branches_, idx_=None):
     X = tree2array(tree, start=start_, stop=stop_, branches=branches_)
-    try: 
-        X = np.array([x[0][0] for x in X])
-    except:
-        print ("loading single")
-        X = np.array([x[0] for x in X])
+    X = np.array([np.concatenate(x) for x in X])
+    if idx_ is not None:
+        X = X[:,idx_]
     return X
-
-
 
 @delayed
 def load_X_upsampled(tree, start_, stop_, branches_, readouts, scale, upscale):
@@ -141,10 +137,9 @@ def crop_jet(imgECAL, iphi, ieta):
 
 @delayed
 def crop_jet_block(Xs, iphis, ietas):
-    returnVal = np.array([crop_jet(x,iphi,ieta) for x,iphi,ieta in zip(Xs,iphis,ietas)])
-    print returnVal.shape
-    return returnVal
-
+    X = np.array([crop_jet(x,iphi,ieta) for x,iphi,ieta in zip(Xs,iphis,ietas)])
+    #print X.shape
+    return X
 
 for j,decay in enumerate(decays):
 
@@ -153,7 +148,8 @@ for j,decay in enumerate(decays):
         pass
         #continue
 
-    tfile_str = 'output.root'
+    tfile_str = 'output_dijet.root'
+    #tfile_str = 'output_ggqq.root'
     #tfile_str = 'output_numEvent20.root'
     #tfile_str = '%s/%s_IMG.root'%(eosDir,decay)
     #tfile_str = '%s/ggtree_mc_single.root'%(eosDir)
@@ -175,12 +171,12 @@ for j,decay in enumerate(decays):
     if neff > nevts:
         neff = int(nevts)
         chunk_size = int(nevts)
+    if neff > chunk_size:
+        assert neff%chunk_size == 0
     print " >> Doing decay:", decay
     print " >> Input file:", tfile_str
     print " >> Total events:", nevts
     print " >> Effective events:", neff
-
-
 
     ## eventId
     ##branches = ["event"]
@@ -328,78 +324,97 @@ for j,decay in enumerate(decays):
     X_EB = da.concatenate([X_EB, X_HBHE_EB_up], axis=-1)
     print " >> %s: %s"%('X_EB', X_EB.shape)
 
-    # m0
-    branches = ["m0"]
-    m0 = da.concatenate([\
-                da.from_delayed(\
-                    load_single(tree,i,i+chunk_size, branches),\
-                    shape=(chunk_size,),\
-                    dtype=np.float32)\
-                for i in range(0,neff,chunk_size)])
-    print " >> Expected shape m0:", m0.shape
+    for ijet in [0,1]:
 
-    # jet seed iphi
-    branches = ["jetSeed_iphi"]
-    jetSeed_iphi = da.concatenate([\
-                da.from_delayed(\
-                    load_vector(tree,i,i+chunk_size, branches),\
-                    shape=(chunk_size,),\
-                    dtype=np.float32)\
-                for i in range(0,neff,chunk_size)])
-    print " >> Expected shape jetSeed_iphi:", jetSeed_iphi.shape
+        print ' >> jet index',ijet
 
-    # jet seed ieta
-    branches = ["jetSeed_ieta"]
-    jetSeed_ieta = da.concatenate([\
-                da.from_delayed(\
-                    load_vector(tree,i,i+chunk_size, branches),\
-                    shape=(chunk_size,),\
-                    dtype=np.float32)\
-                for i in range(0,neff,chunk_size)])
-    print " >> Expected shape jetSeed_ieta:", jetSeed_ieta.shape
+        # jet m0
+        branches = ["jetM"]
+        jetM = da.concatenate([\
+                    da.from_delayed(\
+                        load_vector(tree,i,i+chunk_size,branches,ijet),\
+                        shape=(chunk_size,),\
+                        dtype=np.float32)\
+                    for i in range(0,neff,chunk_size)])
+        print "  >> jetM:", jetM.shape
 
-    X_jets = da.concatenate([\
-                da.from_delayed(\
-                    crop_jet_block(X_ECAL_stacked[i:i+chunk_size], jetSeed_iphi[i:i+chunk_size], jetSeed_ieta[i:i+chunk_size]),\
-                    shape=(chunk_size, jet_shape, jet_shape, 3),\
-                    dtype=np.float32)\
-                for i in range(0,neff,chunk_size)])
+        # jet pt
+        branches = ["jetPt"]
+        jetPt = da.concatenate([\
+                    da.from_delayed(\
+                        load_vector(tree,i,i+chunk_size,branches,ijet),\
+                        shape=(chunk_size,),\
+                        dtype=np.float32)\
+                    for i in range(0,neff,chunk_size)])
+        print "  >> jetPt:", jetPt.shape
 
-    # Class label
-    label = j
-    #label = 1
-    print " >> Class label:",label
-    y = da.from_array(\
-            #np.full(len(eventId), label, dtype=np.float32),\
-            np.full(len(m0), label, dtype=np.float32),\
-            chunks=(chunk_size,))
-    print " >> y shape:",y.shape
-    file_out_str = "test_jets.hdf5"
-    #file_out_str = "test%d_numEvent1.hdf5"%label
-    #file_out_str = "%s/%s_IMGall_RH%d_n%d_label%d.hdf5"%(eosDir,decay,int(scale[0]),neff,label)
-    #file_out_str = "%s/%s_IMG_RH%d_n%dk.hdf5"%(eosDir,decay,int(scale[0]),neff//1000.)
-    #file_out_str = "%s/%s_IMG_EBEEHBup_RH%d_n%dk.hdf5"%(eosDir,decay,int(scale[0]),neff//1000.)
-    #file_out_str = "%s/%s_IMG_RH%d-%d_n%dk.hdf5"%(eosDir,decay,int(scale[0]),int(scale[1]),neff//1000.)
-    print " >> Writing to:", file_out_str
-    #da.to_hdf5(file_out_str, {'/X_EB': X_EB, 'X_EEm': X_EEm, 'X_EEp': X_EEp, 'X_HBHE': X_HBHE, '/y': y}, compression='lzf')
-    #da.to_hdf5(file_out_str, {'/X': X_EB, 'X_EEm': X_EEm, 'X_EEp': X_EEp, 'X_HBHE': X_HBHE, '/y': y}, compression='lzf')
-    da.to_hdf5(file_out_str, {
-                              #'eventId': eventId,
-                              #'runId': runId,
-                              'X_ECAL': X_ECAL,
-                              #'X_ECAL_EEup': X_ECAL_EEup,
-                              'X_ECAL_stacked': X_ECAL_stacked,
-                              'X_EB': X_EB,
-                              'X_EEm': X_EEm,
-                              'X_EEp': X_EEp,
-                              'X_HBHE': X_HBHE,
-                              #'X_HBHE_EM': X_HBHE_EM,
-                              'X_HBHE_EB_up': X_HBHE_EB_up,
-                              'jetSeed_iphi': jetSeed_iphi,
-                              'jetSeed_ieta': jetSeed_ieta,
-                              'X_jets': X_jets,
-                              'm0': m0,
-                              '/y': y
-                              }, compression='lzf')
+        # jet seed iphi
+        branches = ["jetSeed_iphi"]
+        jetSeed_iphi = da.concatenate([\
+                    da.from_delayed(\
+                        load_vector(tree,i,i+chunk_size,branches,ijet),\
+                        shape=(chunk_size,),\
+                        dtype=np.float32)\
+                    for i in range(0,neff,chunk_size)])
+        print "  >> jetSeed_iphi:", jetSeed_iphi.shape
 
-    print " >> Done.\n"
+        # jet seed ieta
+        branches = ["jetSeed_ieta"]
+        jetSeed_ieta = da.concatenate([\
+                    da.from_delayed(\
+                        load_vector(tree,i,i+chunk_size,branches,ijet),\
+                        shape=(chunk_size,),\
+                        dtype=np.float32)\
+                    for i in range(0,neff,chunk_size)])
+        print "  >> jetSeed_ieta:", jetSeed_ieta.shape
+
+        # jet window
+        X_jets = da.concatenate([\
+                    da.from_delayed(\
+                        crop_jet_block(X_ECAL_stacked[i:i+chunk_size], jetSeed_iphi[i:i+chunk_size], jetSeed_ieta[i:i+chunk_size]),\
+                        shape=(chunk_size, jet_shape, jet_shape, 3),\
+                        dtype=np.float32)\
+                    for i in range(0,neff,chunk_size)])
+
+        # Class label
+        label = j
+        #label = 1
+        print "  >> Class label:",label
+        y = da.from_array(\
+                #np.full(len(eventId), label, dtype=np.float32),\
+                np.full(len(X_jets), label, dtype=np.float32),\
+                chunks=(chunk_size,))
+        print "  >> y shape:",y.shape
+
+        file_out_str = "test_dijet_ijet%d.hdf5"%(ijet)
+        #file_out_str = "test%d_numEvent1.hdf5"%label
+        #file_out_str = "%s/%s_IMGall_RH%d_n%d_label%d.hdf5"%(eosDir,decay,int(scale[0]),neff,label)
+        #file_out_str = "%s/%s_IMG_RH%d_n%dk.hdf5"%(eosDir,decay,int(scale[0]),neff//1000.)
+        #file_out_str = "%s/%s_IMG_EBEEHBup_RH%d_n%dk.hdf5"%(eosDir,decay,int(scale[0]),neff//1000.)
+        #file_out_str = "%s/%s_IMG_RH%d-%d_n%dk.hdf5"%(eosDir,decay,int(scale[0]),int(scale[1]),neff//1000.)
+        print "  >> Writing to:", file_out_str
+        if os.path.isfile(file_out_str):
+            os.remove(file_out_str)
+        #da.to_hdf5(file_out_str, {'/X_EB': X_EB, 'X_EEm': X_EEm, 'X_EEp': X_EEp, 'X_HBHE': X_HBHE, '/y': y}, compression='lzf')
+        #da.to_hdf5(file_out_str, {'/X': X_EB, 'X_EEm': X_EEm, 'X_EEp': X_EEp, 'X_HBHE': X_HBHE, '/y': y}, compression='lzf')
+        da.to_hdf5(file_out_str, {
+                                  #'eventId': eventId,
+                                  #'runId': runId,
+                                  'X_ECAL': X_ECAL,
+                                  #'X_ECAL_EEup': X_ECAL_EEup,
+                                  'X_ECAL_stacked': X_ECAL_stacked,
+                                  'X_EB': X_EB,
+                                  'X_EEm': X_EEm,
+                                  'X_EEp': X_EEp,
+                                  'X_HBHE': X_HBHE,
+                                  #'X_HBHE_EM': X_HBHE_EM,
+                                  'X_HBHE_EB_up': X_HBHE_EB_up,
+                                  'jetSeed_iphi': jetSeed_iphi,
+                                  'jetSeed_ieta': jetSeed_ieta,
+                                  'X_jets': X_jets,
+                                  'jetPt': jetPt,
+                                  'jetM': jetM,
+                                  '/y': y
+                                  }, compression='lzf')
+
+        print "  >> Done.\n"

--- a/runRHAnalyzer.py
+++ b/runRHAnalyzer.py
@@ -5,7 +5,9 @@ cfg='RecHitAnalyzer/python/ConfFile_cfg.py'
 #inputFiles_='file:/eos/cms/store/user/mandrews/ML/AODSIM/T7WgStealth_800_200_AODSIM_noPU/180227_224514/0000/step_AODSIM_1.root'
 #inputFiles_='file:/eos/cms/store/user/mandrews/ML/AODSIM/WZToJets_TuneCUETP8M1_13TeV_pythia8_noPU_AODSIM/0/0000/step_full_1.root'
 #inputFiles_='/store/user/johnda/AODSIM/Py8PtGun_bb_noPU_AODSIM/180731_210318/0000/step_AODSIM_1.root'
-inputFiles_='/store/user/johnda/AODSIM/Py8PtGun_bb_noPU_AODSIM/180731_210318/0000/step_AODSIM_2.root'
+#inputFiles_='/store/user/johnda/AODSIM/Py8PtGun_bb_noPU_AODSIM/180731_210318/0000/step_AODSIM_2.root'
+inputFiles_='file:/eos/uscms/store/group/lpcml/QCDToGG_Pt_80_120_13TeV_TuneCUETP8M1_noPU_AODSIM/180809_215549/0000/step_full_1.root'
+#inputFiles_='file:../step_full.root'
 
 maxEvents_=-1
 skipEvents_=0#

--- a/runRHAnalyzer_All.py
+++ b/runRHAnalyzer_All.py
@@ -7,7 +7,8 @@ parser = argparse.ArgumentParser(description='Run RHAnalyzer')
 parser.add_argument('-d','--decay', required=True, help='Decay:Single*Pt50',type=str)
 args = parser.parse_args()
 
-eosDir='/eos/cms/store/user/mandrews/ML'
+eosDir='/eos/uscms/store/user/mba2012'
+#eosDir='/eos/cms/store/user/mandrews/ML'
 #decay='%s_FEVTDEBUG'%args.decay
 decay=args.decay
 
@@ -23,6 +24,7 @@ with open(listname, 'w') as list_file:
 maxEvents_=-1
 skipEvents_=0
 
+decay=decay.replace('_AODSIM','')
 #cmd="cmsRun %s inputFiles=%s maxEvents=%d skipEvents=%d"%(cfg,inputFiles_,maxEvents_,skipEvents_)
 cmd="cmsRun %s inputFiles_load=%s maxEvents=%d skipEvents=%d outputFile=%s/IMGs/%s_IMG.root"%(cfg,listname,maxEvents_,skipEvents_,eosDir,decay)
 #print '%s'%cmd


### PR DESCRIPTION
- **Decouple jet seed finding routine from explicit jet selection to allow different user-specific selection:** Each jet selection returns a `bool RecHitAnalyzer::runEvtSel_jet_*()` determining whether the event should be processed, and fills a vector of selected jet indices (`RecHitAnalyzer::vJetIdxs()` sorted from highest to lowest pT) which are passed to the jet seed-finding, `RecHitAnalyzer::runEvtSel_jet()`.
- Add generic dijet jet selection, `RecHitAnalyzer::runEvtSel_jet_dijet()`.
- Add dijet gg or qq jet selection with DeltaR matching to gen-level hard scatter partons, `RecHitAnalyzer::runEvtSel_jet_dijet_gg_qq()`. Also writes out jet constituent 4-momenta.
- Modify jet image cropping scripts to write out one file per jet index.
- Move RHAnalyzer process parameters to separate cfi file.