### PR TITLE
SCRegressor: Split code into shower selection, seed finding, and image filling.

### DIFF
--- a/RecHitAnalyzer/interface/RecHitAnalyzer.h
+++ b/RecHitAnalyzer/interface/RecHitAnalyzer.h
@@ -253,14 +253,4 @@ static const double eta_bins_HBHE[2*(hcaldqm::constants::IETA_MAX_HE-1)+1] =
 // static data member definitions
 //
 
-//
-// constructors and destructor
-//
-//RecHitAnalyzer::~RecHitAnalyzer()
-//{
-//
-//  // do anything here that needs to be done at desctruction time
-//  // (e.g. close files, deallocate resources etc.)
-//
-//}
 #endif

--- a/RecHitAnalyzer/interface/SCRegressor.h
+++ b/RecHitAnalyzer/interface/SCRegressor.h
@@ -82,7 +82,6 @@ class SCRegressor : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
     edm::EDGetTokenT<reco::GenParticleCollection> genParticleCollectionT_;
     edm::EDGetTokenT<reco::GenJetCollection> genJetCollectionT_;
 
-
     static const int nPhotons = 2;
     //static const int nPhotons = 1;
 
@@ -92,8 +91,8 @@ class SCRegressor : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
     std::vector<float> vEB_time_;
 
     //TH1D * histo;
-    TH2D * hSC_energy[nPhotons];
-    TH2D * hSC_time[nPhotons];
+    TProfile2D * hSC_energy;
+    TProfile2D * hSC_time;
     TH1F * hSC_mass;
     TH1F * hDR;
     TH1F * hdEta;
@@ -103,7 +102,10 @@ class SCRegressor : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
 
     TTree* RHTree;
 
-    float eventId_;
+    unsigned int nPho;
+    unsigned long long eventId_;
+    unsigned int runId_;
+    unsigned int lumiId_;
 
     void branchesSC ( TTree*, edm::Service<TFileService>& );
     void branchesEB ( TTree*, edm::Service<TFileService>& );
@@ -115,26 +117,28 @@ class SCRegressor : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
     bool runPhoSel ( const edm::Event&, const edm::EventSetup& );
     void fillPhoSel     ( const edm::Event&, const edm::EventSetup& );
 
-    std::vector<int> vGenPi0Idxs_;
+    std::map<unsigned int, std::vector<unsigned int>> mGenPi0_RecoPho;
     std::vector<int> vPreselPhoIdxs_;
     std::vector<int> vRegressPhoIdxs_;
     std::vector<float> vIphi_Emax;
     std::vector<float> vIeta_Emax;
 
-    std::vector<float> vEB_SCenergy_;
-    std::vector<float> vSC_energy_[nPhotons];
-    std::vector<float> vSC_energyT_[nPhotons];
-    std::vector<float> vSC_energyZ_[nPhotons];
-    std::vector<float> vSC_time_[nPhotons];
-    float vPho_pT_[nPhotons];
-    float vPho_E_[nPhotons];
-    float vPho_eta_[nPhotons];
-    float vPho_phi_[nPhotons];
-    float vPho_r9_[nPhotons];
-    float vPho_sieie_[nPhotons];
-    float vSC_mass_[nPhotons];
-    float vSC_DR_[nPhotons];
-    float vSC_pT_[nPhotons];
+    //std::vector<std::vector<float>> vEB_SCenergy_;
+    std::vector<std::vector<float>> vSC_energy_;
+    std::vector<std::vector<float>> vSC_energyT_;
+    std::vector<std::vector<float>> vSC_energyZ_;
+    std::vector<std::vector<float>> vSC_time_;
+
+    std::vector<float> vPho_pT_;
+    std::vector<float> vPho_E_;
+    std::vector<float> vPho_eta_;
+    std::vector<float> vPho_phi_;
+    std::vector<float> vPho_r9_;
+    std::vector<float> vPho_sieie_;
+
+    std::vector<float> vSC_mass_;
+    std::vector<float> vSC_DR_;
+    std::vector<float> vSC_pT_;
 
     int nTotal, nPassed;
 
@@ -154,8 +158,8 @@ class SCRegressor : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
 static const float zs = 0.;
 
 static const int crop_size = 32;
-static const bool debug = true;
-//static const bool debug = false;
+//static const bool debug = true;
+static const bool debug = false;
 
 static const int EB_IPHI_MIN = EBDetId::MIN_IPHI;//1;
 static const int EB_IPHI_MAX = EBDetId::MAX_IPHI;//360;

--- a/RecHitAnalyzer/interface/SCRegressor.h
+++ b/RecHitAnalyzer/interface/SCRegressor.h
@@ -98,7 +98,7 @@ class SCRegressor : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
     TH1F * hdEta;
     TH1F * hdPhi;
     TH3F * hdPhidEta;
-    TH1F * hPt;
+    TH1F * hSC_pT;
 
     TTree* RHTree;
 
@@ -116,12 +116,15 @@ class SCRegressor : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
     void branchesPhoSel ( TTree*, edm::Service<TFileService>& );
     bool runPhoSel ( const edm::Event&, const edm::EventSetup& );
     void fillPhoSel     ( const edm::Event&, const edm::EventSetup& );
+    void branchesPhoSel_gamma ( TTree*, edm::Service<TFileService>& );
+    bool runPhoSel_gamma ( const edm::Event&, const edm::EventSetup& );
+    void fillPhoSel_gamma     ( const edm::Event&, const edm::EventSetup& );
 
     std::map<unsigned int, std::vector<unsigned int>> mGenPi0_RecoPho;
     std::vector<int> vPreselPhoIdxs_;
     std::vector<int> vRegressPhoIdxs_;
-    std::vector<float> vIphi_Emax;
-    std::vector<float> vIeta_Emax;
+    std::vector<float> vIphi_Emax_;
+    std::vector<float> vIeta_Emax_;
 
     //std::vector<std::vector<float>> vEB_SCenergy_;
     std::vector<std::vector<float>> vSC_energy_;

--- a/RecHitAnalyzer/interface/SCRegressor.h
+++ b/RecHitAnalyzer/interface/SCRegressor.h
@@ -1,0 +1,168 @@
+#ifndef SCRegressor_h
+#define SCRegressor_h
+// -*- C++ -*-
+//
+// Package:    MLAnalyzer/SCRegressor
+// Class:      SCRegressor
+//
+//
+// Original Author:  Michael Andrews
+//         Created:  Mon, 17 Jul 2017 15:59:54 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
+#include "DataFormats/EcalDetId/interface/EcalTrigTowerDetId.h"
+#include "Geometry/CaloTopology/interface/EcalBarrelTopology.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/EgammaCandidates/interface/Photon.h"
+#include "DataFormats/EgammaCandidates/interface/PhotonFwd.h" // reco::PhotonCollection defined here
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "TH1.h"
+#include "TH2.h"
+#include "TH3.h"
+#include "TTree.h"
+#include "TStyle.h"
+#include "TMath.h"
+#include "TProfile2D.h"
+
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "DataFormats/JetReco/interface/GenJetCollection.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
+
+//
+// class declaration
+//
+
+// If the analyzer does not use TFileService, please remove
+// the template argument to the base class so the class inherits
+// from  edm::one::EDAnalyzer<> and also remove the line from
+// constructor "usesResource("TFileService");"
+// This will improve performance in multithreaded jobs.
+
+class SCRegressor : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
+  public:
+    explicit SCRegressor(const edm::ParameterSet&);
+    ~SCRegressor();
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+
+  private:
+    virtual void beginJob() override;
+    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+    virtual void endJob() override;
+
+    // ----------member data ---------------------------
+    //edm::EDGetTokenT<edm::View<reco::GsfElectron>> electronCollectionT_;
+    edm::EDGetTokenT<reco::GsfElectronCollection> electronCollectionT_;
+    edm::EDGetTokenT<reco::PhotonCollection> photonCollectionT_;
+    edm::EDGetTokenT<EcalRecHitCollection> EBRecHitCollectionT_;
+    edm::EDGetTokenT<reco::GenParticleCollection> genParticleCollectionT_;
+    edm::EDGetTokenT<reco::GenJetCollection> genJetCollectionT_;
+
+
+    static const int nPhotons = 2;
+    //static const int nPhotons = 1;
+
+    TProfile2D *hEB_energy;
+    TProfile2D *hEB_time;
+    std::vector<float> vEB_energy_;
+    std::vector<float> vEB_time_;
+
+    //TH1D * histo;
+    TH2D * hSC_energy[nPhotons];
+    TH2D * hSC_time[nPhotons];
+    TH1F * hSC_mass;
+    TH1F * hDR;
+    TH1F * hdEta;
+    TH1F * hdPhi;
+    TH3F * hdPhidEta;
+    TH1F * hPt;
+
+    TTree* RHTree;
+
+    float eventId_;
+
+    void branchesSC ( TTree*, edm::Service<TFileService>& );
+    void branchesEB ( TTree*, edm::Service<TFileService>& );
+
+    void fillSC     ( const edm::Event&, const edm::EventSetup& );
+    void fillEB     ( const edm::Event&, const edm::EventSetup& );
+
+    void branchesPhoSel ( TTree*, edm::Service<TFileService>& );
+    bool runPhoSel ( const edm::Event&, const edm::EventSetup& );
+    void fillPhoSel     ( const edm::Event&, const edm::EventSetup& );
+
+    std::vector<int> vGenPi0Idxs_;
+    std::vector<int> vPreselPhoIdxs_;
+    std::vector<int> vRegressPhoIdxs_;
+    std::vector<float> vIphi_Emax;
+    std::vector<float> vIeta_Emax;
+
+    std::vector<float> vEB_SCenergy_;
+    std::vector<float> vSC_energy_[nPhotons];
+    std::vector<float> vSC_energyT_[nPhotons];
+    std::vector<float> vSC_energyZ_[nPhotons];
+    std::vector<float> vSC_time_[nPhotons];
+    float vPho_pT_[nPhotons];
+    float vPho_E_[nPhotons];
+    float vPho_eta_[nPhotons];
+    float vPho_phi_[nPhotons];
+    float vPho_r9_[nPhotons];
+    float vPho_sieie_[nPhotons];
+    float vSC_mass_[nPhotons];
+    float vSC_DR_[nPhotons];
+    float vSC_pT_[nPhotons];
+
+    int nTotal, nPassed;
+
+    //TProfile2D * hnPho;
+    TH2F * hnPho;
+    TH2F * hnPhoGt2;
+    TH1F * hdR_nPhoGt2;
+    TH2F * hdPhidEta_nPhoGt2;
+    TProfile2D * hdPhidEta_jphoPt_o_iphoPt;
+    TH1F * hjphoPt_o_iphoPt;
+
+};
+
+//
+// constants, enums and typedefs
+//
+static const float zs = 0.;
+
+static const int crop_size = 32;
+static const bool debug = true;
+//static const bool debug = false;
+
+static const int EB_IPHI_MIN = EBDetId::MIN_IPHI;//1;
+static const int EB_IPHI_MAX = EBDetId::MAX_IPHI;//360;
+static const int EB_IETA_MIN = EBDetId::MIN_IETA;//1;
+static const int EB_IETA_MAX = EBDetId::MAX_IETA;//85;
+//
+// static data member definitions
+//
+
+#endif

--- a/RecHitAnalyzer/plugins/SCRegressor.cc
+++ b/RecHitAnalyzer/plugins/SCRegressor.cc
@@ -35,7 +35,11 @@ SCRegressor::SCRegressor(const edm::ParameterSet& iConfig)
   RHTree->Branch("runId",   &runId_);
   RHTree->Branch("lumiId",  &lumiId_);
 
+  RHTree->Branch("SC_iphi", &vIphi_Emax_);
+  RHTree->Branch("SC_ieta", &vIeta_Emax_);
+
   branchesPhoSel ( RHTree, fs );
+  //branchesPhoSel_gamma ( RHTree, fs );
   branchesSC     ( RHTree, fs );
   branchesEB     ( RHTree, fs );
 
@@ -75,6 +79,7 @@ SCRegressor::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   vPreselPhoIdxs_.clear();
   nTotal += nPhotons;
   hasPassed = runPhoSel ( iEvent, iSetup );
+  //hasPassed = runPhoSel_gamma ( iEvent, iSetup );
   if ( !hasPassed ) return; 
 
   // Get coordinates of photon supercluster seed 
@@ -84,8 +89,8 @@ SCRegressor::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   float Emax;
   GlobalPoint pos_Emax;
   std::vector<GlobalPoint> vPos_Emax;
-  vIphi_Emax.clear();
-  vIeta_Emax.clear();
+  vIphi_Emax_.clear();
+  vIeta_Emax_.clear();
   vRegressPhoIdxs_.clear();
   int iphi_, ieta_; // rows:ieta, cols:iphi
   for ( unsigned int i = 0; i < vPreselPhoIdxs_.size(); i++ ) {
@@ -133,8 +138,8 @@ SCRegressor::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
     if ( Emax <= zs ) continue;
     if ( ieta_Emax > 169 - 15 || ieta_Emax < 15 ) continue;
     vRegressPhoIdxs_.push_back( vPreselPhoIdxs_[i] );
-    vIphi_Emax.push_back( iphi_Emax );
-    vIeta_Emax.push_back( ieta_Emax );
+    vIphi_Emax_.push_back( iphi_Emax );
+    vIeta_Emax_.push_back( ieta_Emax );
     vPos_Emax.push_back( pos_Emax );
     //std::cout << " >> Found: iphi_Emax,ieta_Emax: " << iphi_Emax << ", " << ieta_Emax << std::endl;
     nPho++;
@@ -147,6 +152,7 @@ SCRegressor::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   if ( debug ) std::cout << " >> Passed cropping. " << std::endl;
 
   fillPhoSel ( iEvent, iSetup );
+  //fillPhoSel_gamma ( iEvent, iSetup );
   fillSC     ( iEvent, iSetup );
   fillEB     ( iEvent, iSetup );
 

--- a/RecHitAnalyzer/plugins/SCRegressor.cc
+++ b/RecHitAnalyzer/plugins/SCRegressor.cc
@@ -3,147 +3,14 @@
 // Package:    MLAnalyzer/SCRegressor
 // Class:      SCRegressor
 // 
-/**\class SCRegressor SCRegressor.cc MLAnalyzer/SCRegressor/plugins/SCRegressor.cc
-
-Description: [one line class summary]
-
-Implementation:
-[Notes on implementation]
-*/
 //
 // Original Author:  Michael Andrews
 //         Created:  Mon, 17 Jul 2017 15:59:54 GMT
 //
 //
 
-
-// system include files
-#include <memory>
-
-// user include files
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
-
-#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
-#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
-#include "DataFormats/EcalDetId/interface/EcalTrigTowerDetId.h"
-#include "Geometry/CaloTopology/interface/EcalBarrelTopology.h"
-#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
-#include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
-
-#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
-#include "DataFormats/EgammaCandidates/interface/Photon.h"
-#include "DataFormats/EgammaCandidates/interface/PhotonFwd.h" // reco::PhotonCollection defined here
-
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "CommonTools/UtilAlgos/interface/TFileService.h"
-#include "TH1.h"
-#include "TH2.h"
-#include "TH3.h"
-#include "TTree.h"
-#include "TStyle.h"
-#include "TMath.h"
-#include "TProfile2D.h"
-
-#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
-#include "DataFormats/JetReco/interface/GenJetCollection.h"
-#include "DataFormats/Math/interface/deltaR.h"
-#include "DataFormats/Math/interface/deltaPhi.h"
-
-//
-// class declaration
-//
-
-// If the analyzer does not use TFileService, please remove
-// the template argument to the base class so the class inherits
-// from  edm::one::EDAnalyzer<> and also remove the line from
-// constructor "usesResource("TFileService");"
-// This will improve performance in multithreaded jobs.
-
-class SCRegressor : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
-  public:
-    explicit SCRegressor(const edm::ParameterSet&);
-    ~SCRegressor();
-
-    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-
-
-  private:
-    virtual void beginJob() override;
-    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-    virtual void endJob() override;
-
-    // ----------member data ---------------------------
-    //edm::EDGetTokenT<edm::View<reco::GsfElectron>> electronCollectionT_;
-    edm::EDGetTokenT<reco::GsfElectronCollection> electronCollectionT_;
-    edm::EDGetTokenT<reco::PhotonCollection> photonCollectionT_;
-    edm::EDGetTokenT<EcalRecHitCollection> EBRecHitCollectionT_;
-    edm::EDGetTokenT<reco::GenParticleCollection> genParticleCollectionT_;
-    edm::EDGetTokenT<reco::GenJetCollection> genJetCollectionT_;
-
-    static const int nPhotons = 2;
-    //static const int nPhotons = 1;
-    static const int crop_size = 32;
-    //static const bool debug = true;
-    static const bool debug = false;
-
-    //TH1D * histo; 
-    TH2D * hEB_energy; 
-    TH2D * hSC_energy[nPhotons]; 
-    TH2D * hSC_time[nPhotons]; 
-    TH1F * hSC_mass; 
-    TH1F * hDR; 
-    TH1F * hdEta; 
-    TH1F * hdPhi; 
-    TH3F * hdPhidEta; 
-    TH1F * hPt; 
-
-    TTree* RHTree;
-
-    float eventId_;
-    std::vector<float> vEB_energy_;
-    std::vector<float> vEB_SCenergy_;
-    std::vector<float> vSC_energy_[nPhotons];
-    std::vector<float> vSC_energyT_[nPhotons];
-    std::vector<float> vSC_energyZ_[nPhotons];
-    std::vector<float> vSC_time_[nPhotons];
-    float vPho_pT_[nPhotons];
-    float vPho_E_[nPhotons];
-    float vPho_eta_[nPhotons];
-    float vPho_phi_[nPhotons];
-    float vPho_r9_[nPhotons];
-    float vPho_sieie_[nPhotons];
-    float vSC_mass_[nPhotons];
-    float vSC_DR_[nPhotons];
-    float vSC_pT_[nPhotons];
-
-    float getEMJetMass( reco::GenJetRef, const GlobalPoint& );
-    int nTotal, nPassed;
-
-    //TProfile2D * hnPho;
-    TH2F * hnPho;
-    TH2F * hnPhoGt2;
-    TH1F * hdR_nPhoGt2;
-    TH2F * hdPhidEta_nPhoGt2;
-    TProfile2D * hdPhidEta_jphoPt_o_iphoPt;
-    TH1F * hjphoPt_o_iphoPt;
-
-};
-
-//
-// constants, enums and typedefs
-//
-static const float zs = 0.;
-
-//
-// static data member definitions
-//
+#include "MLAnalyzer/RecHitAnalyzer/interface/SCRegressor.h"
+//#include "MLAnalyzer/RecHitAnalyzer/interface/RecHitAnalyzer.h"
 
 //
 // constructors and destructor
@@ -162,79 +29,13 @@ SCRegressor::SCRegressor(const edm::ParameterSet& iConfig)
   usesResource("TFileService");
   edm::Service<TFileService> fs;
 
-  // Histograms
-  char hname[50], htitle[50];
-  // EB rechits
-  hEB_energy = fs->make<TH2D>("EB_energy", "E(i#phi,i#eta);i#phi;i#eta",
-      EBDetId::MAX_IPHI  , EBDetId::MIN_IPHI-1, EBDetId::MAX_IPHI,
-      2*EBDetId::MAX_IETA,-EBDetId::MAX_IETA,   EBDetId::MAX_IETA );
-  // EB SCs
-  for(int iPho (0); iPho < nPhotons; iPho++) {
-    sprintf(hname, "SC_energy%d",iPho);
-    sprintf(htitle,"E(i#phi,i#eta);iphi;ieta");
-    hSC_energy[iPho] = fs->make<TH2D>(hname, htitle,
-        crop_size, 0, crop_size,
-        crop_size, 0, crop_size );
-    sprintf(hname, "SC_time%d",iPho);
-    sprintf(htitle,"t(i#phi,i#eta);iphi;ieta");
-    hSC_time[iPho] = fs->make<TH2D>(hname, htitle,
-        crop_size, 0, crop_size,
-        crop_size, 0, crop_size );
-  }
-  hSC_mass = fs->make<TH1F>("SC_mass", "m_{SC};m_{SC}",50, 0., 0.5);
-  hDR = fs->make<TH1F>("DR_seed_subJet", "#DeltaR(seed,subJet);#DeltaR",50, 0., 50.*0.0174);
-  hdEta = fs->make<TH1F>("dEta_seed_subJet", "#Delta#eta(seed,subJet);#Delta#eta",50, 0., 50.*0.0174);
-  hdPhi = fs->make<TH1F>("dPhi_seed_subJet", "#Delta#phi(seed,subJet);#Delta#phi",50, 0., 50.*0.0174);
-  hdPhidEta = fs->make<TH3F>("dPhidEta_GG", "#Delta(#phi,#eta,m);#Delta#phi(#gamma,#gamma);#Delta#eta(#gamma,#gamma);m",6, 0., 6.*0.0174, 6, 0., 6.*0.0174, 16., 0.,1.6);
-  hPt = fs->make<TH1F>("Pt", "Pt", 65, 30., 160.);
   // Output Tree
   RHTree = fs->make<TTree>("RHTree", "RecHit tree");
+  branchesPhoSel ( RHTree, fs );
+  branchesSC ( RHTree, fs );
+  branchesEB ( RHTree, fs );
   RHTree->Branch("eventId",      &eventId_);
-  RHTree->Branch("EB_energy",    &vEB_energy_);
-  //RHTree->Branch("EB_SCenergy",  &vSC_energy_);
-  for(int iPho (0); iPho < nPhotons; iPho++) {
-    sprintf(hname, "SC_energy%d",iPho);
-    RHTree->Branch(hname,          &vSC_energy_[iPho]);
-    sprintf(hname, "SC_energyT%d",iPho);
-    RHTree->Branch(hname,          &vSC_energyT_[iPho]);
-    sprintf(hname, "SC_energyZ%d",iPho);
-    RHTree->Branch(hname,          &vSC_energyZ_[iPho]);
-    sprintf(hname, "SC_time%d",iPho);
-    RHTree->Branch(hname,          &vSC_time_[iPho]);
-    sprintf(hname, "SC_mass%d",iPho);
-    RHTree->Branch(hname,          &vSC_mass_[iPho]);
-    sprintf(hname, "SC_DR%d",iPho);
-    RHTree->Branch(hname,          &vSC_DR_[iPho]);
-    sprintf(hname, "SC_pT%d",iPho);
-    RHTree->Branch(hname,          &vSC_pT_[iPho]);
-    sprintf(hname, "pho_pT%d",iPho);
-    RHTree->Branch(hname,      &vPho_pT_[iPho]);
-    sprintf(hname, "pho_E%d",iPho);
-    RHTree->Branch(hname,      &vPho_E_[iPho]);
-    sprintf(hname, "pho_eta%d",iPho);
-    RHTree->Branch(hname,      &vPho_eta_[iPho]);
-    sprintf(hname, "pho_phi%d",iPho);
-    RHTree->Branch(hname,      &vPho_phi_[iPho]);
-    sprintf(hname, "pho_r9%d",iPho);
-    RHTree->Branch(hname,      &vPho_r9_[iPho]);
-    sprintf(hname, "pho_sieie%d",iPho);
-    RHTree->Branch(hname,      &vPho_sieie_[iPho]);
-  }
 
-  //hnPho = fs->make<TProfile2D>("nPho", "N(m_{#pi},p_{T,#pi})_{reco};m_{#pi^{0}};p_{T,#pi^0}",
-      //8, 0., 1.6, 8, 15., 100.);
-  hnPho = fs->make<TH2F>("nPho", "N(m_{#pi},p_{T,#pi})_{reco};m_{#pi^{0}};p_{T,#pi^0}",
-      16, 0., 1.6, 17, 15., 100.);
-  hnPhoGt2 = fs->make<TH2F>("nPhoGt2", "N_{#gamma #geq 2}(m_{#pi},p_{T,#pi})_{reco};m_{#pi^{0}};p_{T,#pi^0}",
-      8, 0., 1.6, 8, 15., 100.);
-  hdR_nPhoGt2 = fs->make<TH1F>("dR_nPho_gt_2", "#DeltaR(#gamma,#Gamma)_{reco};#DeltaR",
-      24, 0., 6.*0.0174);
-  hdPhidEta_nPhoGt2 = fs->make<TH2F>("dPhidEta_nPho_gt_2", "N_{#gamma,reco} #geq 2};#Delta#phi(#gamma,#Gamma);#Delta#eta(#gamma,#Gamma)",
-      6, 0., 6.*0.0174, 6, 0., 6.*0.0174);
-  hdPhidEta_jphoPt_o_iphoPt = fs->make<TProfile2D>("dPhidEta_jphoPt_o_iphoPt", "p_{T,#gamma} / p_{T,#Gamma};#Delta#phi(#gamma,#Gamma);#Delta#eta(#gamma,#Gamma)",
-      6, 0., 6.*0.0174, 6, 0., 6.*0.0174);
-  hjphoPt_o_iphoPt = fs->make<TH1F>("jphoPt_o_iphoPt", "p_{T,#gamma} / p_{T,#Gamma};f",
-      25, 0., 1.);
 }
 
 
@@ -250,62 +51,7 @@ SCRegressor::~SCRegressor()
 //
 // member functions
 //
-const math::XYZTLorentzVector getFinalP4( const reco::Candidate* phoCand ) {
-  if ( phoCand->status() == 1 ) {
-    return phoCand->p4();
-  } else {
-    if ( phoCand->numberOfDaughters() == 1 )
-      return getFinalP4( phoCand->daughter(0) );
-    else
-      return phoCand->p4();
-  }
-}
-
-float SCRegressor::getEMJetMass( reco::GenJetRef iJet, const GlobalPoint & seed )
-{
-    unsigned int nConstituents = iJet->getGenConstituents().size();
-    //const std::vector <const reco::GenParticle*> jetConstituents = iJet->getGenConstituents();
-    if ( debug ) std::cout << " >> nConst:" << nConstituents << " eta:" << iJet->eta() << " phi:" << iJet->phi() << std::endl;
-    if ( debug ) std::cout << " >> seed eta:" << seed.eta() << " phi:" << seed.phi() << std::endl;
-
-    int nSelConst = 0;
-    float dR, dEta, dPhi;
-    //math::PtEtaPhiELorentzVectorD jetP4;
-    math::XYZTLorentzVector jetP4;
-    for ( unsigned int j = 0; j < nConstituents; j++ ) {
-      const reco::GenParticle* subJet = iJet->getGenConstituent( j );
-      if ( debug ) {
-        std::cout << " >> pdgId:" << subJet->pdgId() << " status:" << subJet->status()
-        << " pT:" << subJet->pt() << " eta:" << subJet->eta() << " phi: " << subJet->phi() << " E:" << subJet->energy();
-        std::cout << " moth:" << subJet->mother()->pdgId();
-        std::cout << std::endl;
-      }
-      if ( std::abs(subJet->pdgId()) != 22 && std::abs(subJet->pdgId()) != 11 ) continue;
-      if ( subJet->status() != 1 ) continue;
-      if ( subJet->mother()->pdgId() != 111 && subJet->mother()->pdgId() != 35 ) continue;
-      //dR = reco::deltaR( seed.eta(),seed.phi(), subJet->eta(),subJet->phi() );
-      //dPhi = reco::deltaPhi( seed.phi(), subJet->phi() );
-      //dEta = std::abs( seed.eta() - subJet->eta() );
-      dR = reco::deltaR( iJet->eta(),iJet->phi(), subJet->eta(),subJet->phi() );
-      dPhi = reco::deltaPhi( iJet->phi(), subJet->phi() );
-      dEta = std::abs( iJet->eta() - subJet->eta() );
-      //if ( dPhi > TMath::Pi() ) dPhi =- TMath::Pi();
-      hDR->Fill( dR );
-      hdEta->Fill( dEta );
-      hdPhi->Fill( dPhi );
-      if ( debug ) std::cout << " >> dR:" << dR << " dEta:" << dEta << " dPhi:" << dPhi << std::endl;
-      if ( dR > (6*0.0174) ) continue;
-      //if ( dR > (4*0.0174) ) continue;
-      jetP4 += subJet->p4();
-      nSelConst++;
-    }
-    if ( nSelConst == 0 ) return 0.;
-    if ( jetP4.mass() < 1.e-3 ) return 0.;
-    //std::cout << " EMJetMass:" << jetP4.mass() << std::endl;
-    //std::cout << " >> pT:" << iJet->pt() << " eta:" << iJet->eta() << " phi: " << iJet->phi() << " E:" << iJet->energy() << std::endl;
-    return jetP4.mass();
-}
-
+//
 // ------------ method called for each event  ------------
 void
 SCRegressor::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
@@ -315,233 +61,23 @@ SCRegressor::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 
   edm::Handle<EcalRecHitCollection> EBRecHitsH;
   iEvent.getByToken(EBRecHitCollectionT_, EBRecHitsH);
+
   edm::Handle<reco::PhotonCollection> photons;
   iEvent.getByToken(photonCollectionT_, photons);
-  edm::Handle<reco::GenParticleCollection> genParticles;
-  iEvent.getByToken(genParticleCollectionT_, genParticles);
+
   // Provides access to global cell position and coordinates below
   edm::ESHandle<CaloGeometry> caloGeomH;
   iSetup.get<CaloGeometryRecord>().get(caloGeomH);
   const CaloGeometry* caloGeom = caloGeomH.product();
-  if ( debug ) std::cout << " >> PhoCol.size: " << photons->size() << std::endl;
 
-  for(int iPho (0); iPho < nPhotons; iPho++) {
-    vSC_energy_[iPho].assign(crop_size*crop_size,0.);
-    vSC_energyT_[iPho].assign(crop_size*crop_size,0.);
-    vSC_energyZ_[iPho].assign(crop_size*crop_size,0.);
-    vSC_time_[iPho].assign(crop_size*crop_size,0.);
-  }
-  vEB_SCenergy_.assign(EBDetId::kSizeForDenseIndexing,0.);
-
-  int iphi_, ieta_;
-
-  std::vector<int> vGenPi0Idxs_;
-  float dEta, dPhi, dR, mPi0;
-
-  // ____________ Gen-level studies ________________ //
-  int nPi0 = 0;
-  //std::vector<math::PtEtaPhiELorentzVectorD> vPhoPairs[nPhotons];
+  // Run explicit jet selection
+  bool hasPassed;
+  vGenPi0Idxs_.clear();
+  vPreselPhoIdxs_.clear();
   std::vector<math::XYZTLorentzVector> vPhoPairs[nPhotons];
-  std::map<unsigned int, std::vector<unsigned int>> mGenPi0_RecoPho;
-  for ( unsigned int iG = 0; iG < genParticles->size(); iG++ ) {
 
-    reco::GenParticleRef iGen( genParticles, iG );
-    // ID cuts
-    if ( debug ) std::cout << " >> pdgId:"<< iGen->pdgId() << " status:" << iGen->status() << " nDaughters:" << iGen->numberOfDaughters() << std::endl;
-    if ( std::abs(iGen->pdgId()) != 111 ) continue;
-    if ( debug ) std::cout << " >> pdgId:111 nDaughters:" << iGen->numberOfDaughters() << std::endl;
-    if ( iGen->numberOfDaughters() != 2 ) continue;
-    //if ( iGen->mass() > 0.4 ) continue;
-    dR = reco::deltaR( iGen->daughter(0)->eta(),iGen->daughter(0)->phi(), iGen->daughter(1)->eta(),iGen->daughter(1)->phi() );
-    if ( dR > 5*.0174 ) continue;
-
-    vGenPi0Idxs_.push_back( iG );
-    //mGenPi0_GenPho.insert( std::pair<unsigned int, vector<int>>(iG, vector<int>()) );
-    mGenPi0_RecoPho.insert( std::pair<unsigned int, std::vector<unsigned int>>(iG, std::vector<unsigned int>()) );
-
-    for ( unsigned int iD = 0; iD < iGen->numberOfDaughters(); iD++ ) {
-      const reco::Candidate* phoCand = iGen->daughter(iD);
-      vPhoPairs[nPi0].push_back( getFinalP4(phoCand) );
-    }
-    nPi0++;
-
-  } // genParticle loop: count good photons
-  if ( nPi0 != nPhotons ) return;
-
-  ////////// Apply selection and get coordinates of shower max //////////
-  //float ptCut = 45., etaCut = 1.44;
-  float ptCut = 15., etaCut = 1.44;
-
-  // Get reco (pT>5GeV) photons associated to pi0
-  float minDR = 100.;
-  int minDR_idx = -1;
-  // Loop over pi0s
-  for ( auto& mG : mGenPi0_RecoPho ) {
-
-    reco::GenParticleRef iGen( genParticles, mG.first );
-
-    if ( debug ) std::cout << " >> pi0[" << mG.first << "]"<< std::endl;
-    // Loop over photons from pi0
-    for ( unsigned int iD = 0; iD < iGen->numberOfDaughters(); iD++ ) {
-
-      const reco::Candidate* iGenPho = iGen->daughter(iD);
-
-      // Loop over reco photon collection
-      minDR = 100.;
-      minDR_idx = -1;
-      if ( debug ) std::cout << "  >> iD[" << iD << "]" << std::endl;
-      for ( unsigned int iP = 0; iP < photons->size(); iP++ ) {
-
-        reco::PhotonRef iPho( photons, iP );
-        if ( iPho->pt() < 5. ) continue;
-        dR = reco::deltaR( iPho->eta(),iPho->phi(), iGenPho->eta(),iGenPho->phi() );
-        if ( dR > minDR ) continue;
-
-        minDR = dR;
-        minDR_idx = iP;
-        if ( debug ) std::cout << "   >> minDR_idx:" << minDR_idx << " " << minDR << std::endl;
-
-      } // reco photons
-      if ( minDR > 0.04 ) continue;
-      //mG[mG.first].push_back( minDR_idx );
-      mG.second.push_back( minDR_idx );
-      if ( debug ) std::cout << "   >> !minDR_idx:" << minDR_idx << std::endl;
-
-    } // gen photons 
-    dR = reco::deltaR( iGen->daughter(0)->eta(),iGen->daughter(0)->phi(), iGen->daughter(1)->eta(),iGen->daughter(1)->phi() );
-    if ( debug ) std::cout << "   >> gen dR:" << dR << std::endl;
-
-  } // gen pi0s
-
-  // Ensure only 1 reco photon associated to each gen pi0
-  std::vector<int> vRecoPhoIdxs_;
-  for ( auto const& mG : mGenPi0_RecoPho ) {
-    if ( debug ) std::cout << " >> pi0[" << mG.first << "] size:" << mG.second.size() << std::endl; 
-    // Possibilities:
-    // 1) pho_gen1: unmatched, pho_gen2: unmatched => both reco pho failed pT cut or dR matching, reject
-    // 2) pho_gen1: reco-matched1, pho_gen1: unmatched => one reco pho failed pT cut or dR matching, can accept
-    // 3) pho_gen1: reco-matched1, pho_gen2: reco-matched2
-    //    3a) reco-matched1 == reco-matched2 => merged, accept
-    //    3b) reco-matched1 != reco-matched2 => resolved, reject
-    if ( mG.second.size() == 0 ) continue;
-    if ( mG.second.size() == 2 && mG.second[0] != mG.second[1] ) continue; // 2 resolved reco photons 
-    vRecoPhoIdxs_.push_back( mG.second[0] );
-  } 
-
-  // Ensure each of pi0-matched reco photons passes pre-selection
-  // NOTE: at this point there is 1-1 correspondence between pi0 and reco pho,
-  // so suffices to check there are as many pre-selected phos as pi0s
-  bool isIso;
-  std::vector<int> vPreselPhoIdxs_;
-  for ( unsigned int i = 0; i < vRecoPhoIdxs_.size(); i++ ) {
-
-    reco::PhotonRef iPho( photons, vRecoPhoIdxs_[i] );
-
-    if ( iPho->pt() < ptCut ) continue;
-    if ( std::abs(iPho->eta()) > etaCut ) continue;
-    if ( debug ) std::cout << " >> pT: " << iPho->pt() << " eta: " << iPho->eta() << std::endl;
-    if ( iPho->r9() < 0.5 ) continue;
-    if ( iPho->hadTowOverEm() > 0.07 ) continue;
-    if ( iPho->full5x5_sigmaIetaIeta() > 0.0105 ) continue;
-    if ( iPho->hasPixelSeed() == true ) continue;
-
-    // Ensure pre-sel photons are isolated 
-    isIso = true;
-    for ( unsigned int j = 0; j < vRecoPhoIdxs_.size(); j++ ) {
-
-      if ( i == j ) continue;
-      reco::PhotonRef jPho( photons, vRecoPhoIdxs_[j] ); 
-      dR = reco::deltaR( iPho->eta(),iPho->phi(), jPho->eta(),jPho->phi() );
-      if ( debug ) std::cout << "   >> reco dR:" << dR << std::endl;
-      if ( dR > 12*.0174 ) continue;
-      isIso = false;
-      break;
-
-    } // reco photon j
-    if ( !isIso ) continue;
-
-    vPreselPhoIdxs_.push_back( vRecoPhoIdxs_[i] );
-
-  } // reco photon i
-
-  if ( vPreselPhoIdxs_.size() != nPhotons ) return;
-  //TODO: allow variable number of pre-selected photons to be saved per event
-
-  /*
-  // Loop over pre-selected photons
-  std::map<const reco::Candidate*, unsigned int> genRecoPhoMap;
-  for ( unsigned int i = 0; i < vPreselPhoIdxs_.size(); i++ ) {
-
-    reco::PhotonRef iPho( photons, vPreselPhoIdxs_[i] );
-
-    // Ensure only 1 pre-sel photon exists per gen pi0
-    for ( unsigned int iG = 0; iG < genParticles->size(); iG++ ) {
-
-      // Loop over gen photons from pi0
-      reco::GenParticleRef iGen( genParticles, iG );
-      if ( std::abs(iGen->pdgId()) != 22 ) continue;
-      if ( iGen->status() != 1 ) continue; // NOT the same as Pythia status
-      if ( iGen->mother()->pdgId() != 111 ) continue;
-
-      // Declare match to the pre-sel photon if within dR cone 
-      dR = reco::deltaR( iPho->eta(),iPho->phi(), iGen->eta(),iGen->phi() );
-      if ( dR > 0.04 ) continue;
-      //std::cout << " >> gen pho: " << iGen->eta() << ", " << iGen->phi() << ": " << iP <<std::endl;
-
-      // If no pre-sel photon matched to mother pi0, save pairing to dict
-      // If another pre-sel photon is matched to same pi0, declare as double-matched and completely remove pairing 
-      auto pi0It = genRecoPhoMap.find( iGen->mother() );
-
-      if ( pi0It == genRecoPhoMap.end() ) {
-        genRecoPhoMap.insert( std::pair<const reco::Candidate*, unsigned int>(iGen->mother(), vPreselPhoIdxs_[i]) );
-        //std::cout << " >> Adding: " << iGen->mother()->eta() << ", " << iGen->mother()->phi() << ": " << iP <<std::endl;
-      } else {
-        //std::cout << " >> Removing: " << iGen->mother()->eta() << ", " << iGen->mother()->phi() << ": " << iP <<std::endl;
-        genRecoPhoMap.erase( pi0It );
-      } 
-
-      if ( debug ) std::cout << " >> GenPhoMatch | " << " pt:" << iGen->pt() << " dR: " << dR << std::endl;
-      break;
-
-    } // genParticles
-  } // good photons
-
-  // dR studies
-  for ( auto const& iPhoMap : genRecoPhoMap ) {
-
-    reco::PhotonRef iPho( photons, iPhoMap.second );
-    //std::cout << " >> sel pho: " << iPhoMap.second << std::endl;
-
-    int nPhoInDR = 1;
-    for ( unsigned int j = 0; j < photons->size(); j++ ) {
-      if ( iPhoMap.second == j ) continue;
-      reco::PhotonRef iPhoCone( photons, j );
-      dR = reco::deltaR( iPho->eta(),iPho->phi(), iPhoCone->eta(),iPhoCone->phi() );
-      dEta = std::abs( iPho->eta() - iPhoCone->eta() );
-      dPhi = reco::deltaPhi( iPho->phi(), iPhoCone->phi() );
-      if ( dR > 0.0174*5 ) continue;
-      nPhoInDR++;
-      hdPhidEta_nPhoGt2->Fill( dPhi, dEta );
-      hdPhidEta_jphoPt_o_iphoPt->Fill( dPhi, dEta, iPhoCone->pt() / iPho->pt() ); 
-      hdR_nPhoGt2->Fill( dR );
-      hjphoPt_o_iphoPt->Fill( iPhoCone->pt() / iPho->pt() );
-      //std::cout << " >> DR:" << dR << " pT:" << iPho->pt() << std::endl;
-    }
-    //std::cout << " >> nPhoInDR:" << nPhoInDR << std::endl;
-    float mPi0gen_ = (vPhoPairs[0][0] + vPhoPairs[0][1]).mass();
-    reco::GenParticleRef iGen( genParticles, vGenPi0Idxs_[0] );
-    float ptPi0gen_ = iGen->pt(); 
-    //std::cout << " >> nPhoInDR:" << nPhoInDR << " m:" << mPi0gen_ << " pt:" << ptPi0gen_ << std::endl;
-
-    hnPho->Fill( mPi0gen_, ptPi0gen_, 1.*nPhoInDR );
-    if ( nPhoInDR > 1 ) hnPhoGt2->Fill( mPi0gen_, ptPi0gen_);
-    if ( nPhoInDR < 2 ) {
-      hdR_nPhoGt2->Fill( 0. );
-      hjphoPt_o_iphoPt->Fill( 0. );
-    }
-
-  } // dR studies
-  */
+  hasPassed = runPhoSel ( iEvent, iSetup );
+  if ( !hasPassed ) return; 
 
   // Get coordinates of photon supercluster seed 
   int nPho = 0;
@@ -549,9 +85,10 @@ SCRegressor::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   float Emax;
   GlobalPoint pos_Emax;
   std::vector<GlobalPoint> vPos_Emax;
-  std::vector<int> vRegressPhoIdxs_;
-  std::vector<float> vIphi_Emax;
-  std::vector<float> vIeta_Emax;
+  vIphi_Emax.clear();
+  vIeta_Emax.clear();
+  vRegressPhoIdxs_.clear();
+  int iphi_, ieta_; // rows:ieta, cols:iphi
   for ( unsigned int i = 0; i < vPreselPhoIdxs_.size(); i++ ) {
 
     reco::PhotonRef iPho( photons, vPreselPhoIdxs_[i] );
@@ -608,112 +145,11 @@ SCRegressor::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   // Enforce selection
   //std::cout << " >> nPho: " << nPho << std::endl;
   if ( nPho != nPhotons ) return;
-  if ( debug ) std::cout << " >> Passed selection. " << std::endl;
+  if ( debug ) std::cout << " >> Passed cropping. " << std::endl;
 
-  ////////// Store each shower crop //////////
-  for ( unsigned int i = 0; i < nPhotons; i++ ) {
-    reco::PhotonRef iPho( photons, vRegressPhoIdxs_[i] );
-    // Fill branch arrays
-    vPho_pT_[i] = iPho->pt();
-    vPho_E_[i] = iPho->energy();
-    vPho_eta_[i] = iPho->eta();
-    vPho_phi_[i] = iPho->phi();
-    //std::cout << "r9: " << iPho->r9() << std::endl;
-    vPho_r9_[i] = iPho->r9();
-    vPho_sieie_[i] = iPho->full5x5_sigmaIetaIeta(); 
-  } // photons
-  for ( int i = 0; i < nPi0; i++ ) {
-    mPi0 = (vPhoPairs[i][0] + vPhoPairs[i][1]).mass();
-    dR = reco::deltaR( vPhoPairs[i][0].eta(),vPhoPairs[i][0].phi(), vPhoPairs[i][1].eta(),vPhoPairs[i][1].phi() );
-    dEta = std::abs( vPhoPairs[i][0].eta() - vPhoPairs[i][1].eta() );
-    dPhi = reco::deltaPhi( vPhoPairs[i][0].phi(), vPhoPairs[i][1].phi() );
-    if ( debug ) std::cout << " >> m0:" << mPi0 << " dR:" << dR << " dPhi:" << dPhi << std::endl;
-    reco::GenParticleRef iGen( genParticles, vGenPi0Idxs_[i] );
-    vSC_DR_[i] = dR;
-    vSC_pT_[i] = iGen->pt(); 
-    vSC_mass_[i] = mPi0;
-    hPt->Fill( iGen->pt() );
-    hdPhidEta->Fill( dPhi, dEta, mPi0 );
-    hnPho->Fill( mPi0, iGen->pt() );
-  }
-  for ( int i = 0; i < nPhotons; i++ ) {
-    //std::cout << "SC mass " << vSC_mass_[i] << std::endl;
-    hSC_mass->Fill( vSC_mass_[i] );
-  }
-
-  int idx;
-  int iphi_shift, ieta_shift;
-  int iphi_crop, ieta_crop;
-  for(EcalRecHitCollection::const_iterator iRHit = EBRecHitsH->begin();
-      iRHit != EBRecHitsH->end();
-      ++iRHit) {
-
-    if ( iRHit->energy() < zs ) continue;
-
-    // Convert detector coordinates to ordinals
-    EBDetId ebId( iRHit->id() );
-    iphi_ = ebId.iphi()-1; // [0,...,359]
-    ieta_ = ebId.ieta() > 0 ? ebId.ieta()-1 : ebId.ieta(); // [-85,...,-1,0,...,84]
-    ieta_ += EBDetId::MAX_IETA; // [0,...,169]
-
-    for(unsigned iP(0); iP < nPhotons; iP++) {
-
-      iphi_shift = vIphi_Emax[iP] - 15;
-      ieta_shift = vIeta_Emax[iP] - 15;
-      //std::cout << " >> Storing: iphi_Emax,ieta_Emax: " << vIphi_Emax[iP] << ", " << vIeta_Emax[iP] << std::endl;
-
-      // Convert to [0,...,31][0,...,31]
-      ieta_crop = ieta_ - ieta_shift;
-      iphi_crop = iphi_ - iphi_shift;
-      if ( iphi_crop >= EBDetId::MAX_IPHI ) iphi_crop = iphi_crop - EBDetId::MAX_IPHI; // get wrap-around hits
-
-      if ( ieta_crop < 0 || ieta_crop > crop_size-1 ) continue;
-      if ( iphi_crop < 0 || iphi_crop > crop_size-1 ) continue;
-      
-      // Convert to [0,...,32*32-1] 
-      idx = ieta_crop*crop_size + iphi_crop;
-
-      // Cell geometry provides access to (rho,eta,phi) coordinates of cell center
-      //auto cell = caloGeom->getGeometry(ebId);
-      auto pos = caloGeom->getPosition(ebId);
-      
-      // Fill branch arrays 
-      vSC_energy_[iP][idx] = iRHit->energy();
-      //vSC_energyT_[iP][idx] = iRHit->energy()/TMath::CosH(vPho_eta_[iP]);
-      vSC_energyT_[iP][idx] = iRHit->energy()/TMath::CosH(pos.eta());
-      vSC_energyZ_[iP][idx] = iRHit->energy()*std::abs(TMath::TanH(pos.eta()));
-      vSC_time_[iP][idx] = iRHit->time();
-      vEB_SCenergy_[ebId.hashedIndex()] = iRHit->energy();
-      //std::cout << " >> " << iP << ": iphi_,ieta_,E: " << iphi_crop << ", " << ieta_crop << ", " << iRHit->energy() << std::endl; 
-
-      // Fill histograms to monitor cumulative distributions
-      hSC_energy[iP]->Fill( iphi_crop,ieta_crop,iRHit->energy() );
-      hSC_time[iP]->Fill( iphi_crop,ieta_crop,iRHit->time() );
-
-    } // EB rechits
-  } // photons
-
-  // Fill full EB for comparison
-  vEB_energy_.assign(EBDetId::kSizeForDenseIndexing,0.);
-  for(EcalRecHitCollection::const_iterator iRHit = EBRecHitsH->begin();
-      iRHit != EBRecHitsH->end();
-      ++iRHit) {
-
-    // Get detector id and convert to histogram-friendly coordinates
-    EBDetId ebId( iRHit->id() );
-    iphi_ = ebId.iphi()-1;
-    ieta_ = ebId.ieta() > 0 ? ebId.ieta()-1 : ebId.ieta();
-    //std::cout << "ECAL | (ieta,iphi): (" << ebId.ieta() << "," << ebId.iphi() << ")" <<std::endl;
-
-    // Fill some histograms to monitor distributions
-    // These will contain *cumulative* statistics and as such
-    // should be used for monitoring purposes only
-    hEB_energy->Fill( iphi_,ieta_,iRHit->energy() );
-
-    // Fill branch arrays
-    idx = ebId.hashedIndex(); // (ieta_+EBDetId::MAX_IETA)*EBDetId::MAX_IPHI + iphi_
-    vEB_energy_[idx] = iRHit->energy();
-  } // EB rechits
+  fillPhoSel( iEvent, iSetup );
+  fillSC( iEvent, iSetup );
+  fillEB( iEvent, iSetup );
 
   eventId_ = iEvent.id().event();
   nPassed++;

--- a/RecHitAnalyzer/plugins/SCRegressor_fillEB.cc
+++ b/RecHitAnalyzer/plugins/SCRegressor_fillEB.cc
@@ -1,0 +1,63 @@
+#include "MLAnalyzer/RecHitAnalyzer/interface/SCRegressor.h"
+
+// Fill EB rec hits ////////////////////////////////
+// Store event rechits in a vector of length equal
+// to number of crystals in EB (ieta:170 x iphi:360)
+
+//TProfile2D *hEB_energy;
+//TProfile2D *hEB_time;
+//std::vector<float> vEB_energy_;
+//std::vector<float> vEB_time_;
+
+// Initialize branches _____________________________________________________//
+void SCRegressor::branchesEB ( TTree* tree, edm::Service<TFileService> &fs ) {
+
+  // Branches for images
+  tree->Branch("EB_energy", &vEB_energy_);
+  tree->Branch("EB_time",   &vEB_time_);
+
+  // Histograms for monitoring
+  hEB_energy = fs->make<TProfile2D>("EB_energy", "E(i#phi,i#eta);i#phi;i#eta",
+      EB_IPHI_MAX  , EB_IPHI_MIN-1, EB_IPHI_MAX,
+      2*EB_IETA_MAX,-EB_IETA_MAX,   EB_IETA_MAX );
+  hEB_time = fs->make<TProfile2D>("EB_time", "t(i#phi,i#eta);i#phi;i#eta",
+      EB_IPHI_MAX  , EB_IPHI_MIN-1, EB_IPHI_MAX,
+      2*EB_IETA_MAX,-EB_IETA_MAX,   EB_IETA_MAX );
+
+} // branchesEB()
+
+// Fill EB rechits _________________________________________________________________//
+void SCRegressor::fillEB ( const edm::Event& iEvent, const edm::EventSetup& iSetup ) {
+
+  int iphi_, ieta_, idx_; // rows:ieta, cols:iphi
+  float energy_;
+
+  vEB_energy_.assign( EBDetId::kSizeForDenseIndexing, 0. );
+  vEB_time_.assign( EBDetId::kSizeForDenseIndexing, 0. );
+
+  edm::Handle<EcalRecHitCollection> EBRecHitsH_;
+  iEvent.getByToken( EBRecHitCollectionT_, EBRecHitsH_);
+
+  // Fill EB rechits 
+  for ( EcalRecHitCollection::const_iterator iRHit = EBRecHitsH_->begin();
+        iRHit != EBRecHitsH_->end(); ++iRHit ) {
+
+    energy_ = iRHit->energy();
+    if ( energy_ <= zs ) continue;
+    // Get detector id and convert to histogram-friendly coordinates
+    EBDetId ebId( iRHit->id() );
+    iphi_ = ebId.iphi() - 1;
+    ieta_ = ebId.ieta() > 0 ? ebId.ieta()-1 : ebId.ieta();
+    // Fill histograms for monitoring 
+    hEB_energy->Fill( iphi_,ieta_,energy_ );
+    hEB_time->Fill( iphi_,ieta_,iRHit->time() );
+    // Get Hashed Index: provides convenient 
+    // index mapping from [ieta][iphi] -> [idx]
+    idx_ = ebId.hashedIndex(); // (ieta_+EB_IETA_MAX)*EB_IPHI_MAX + iphi_
+    // Fill vectors for images
+    vEB_energy_[idx_] = energy_;
+    vEB_time_[idx_] = iRHit->time();
+
+  } // EB rechits
+
+} // fillEB()

--- a/RecHitAnalyzer/plugins/SCRegressor_fillSC.cc
+++ b/RecHitAnalyzer/plugins/SCRegressor_fillSC.cc
@@ -1,0 +1,103 @@
+#include "MLAnalyzer/RecHitAnalyzer/interface/SCRegressor.h"
+
+// Initialize branches _____________________________________________________//
+void SCRegressor::branchesSC ( TTree* tree, edm::Service<TFileService> &fs )
+{
+  char hname[50], htitle[50];
+  for(int iPho (0); iPho < nPhotons; iPho++) {
+    sprintf(hname, "SC_energy%d",iPho);
+    sprintf(htitle,"E(i#phi,i#eta);iphi;ieta");
+    hSC_energy[iPho] = fs->make<TH2D>(hname, htitle,
+        crop_size, 0, crop_size,
+        crop_size, 0, crop_size );
+    sprintf(hname, "SC_time%d",iPho);
+    sprintf(htitle,"t(i#phi,i#eta);iphi;ieta");
+    hSC_time[iPho] = fs->make<TH2D>(hname, htitle,
+        crop_size, 0, crop_size,
+        crop_size, 0, crop_size );
+  }
+  for(int iPho (0); iPho < nPhotons; iPho++) {
+    sprintf(hname, "SC_energy%d",iPho);
+    RHTree->Branch(hname,          &vSC_energy_[iPho]);
+    sprintf(hname, "SC_energyT%d",iPho);
+    RHTree->Branch(hname,          &vSC_energyT_[iPho]);
+    sprintf(hname, "SC_energyZ%d",iPho);
+    RHTree->Branch(hname,          &vSC_energyZ_[iPho]);
+    sprintf(hname, "SC_time%d",iPho);
+    RHTree->Branch(hname,          &vSC_time_[iPho]);
+  }
+} // branchesSC()
+
+// Fill SC rechits _________________________________________________________________//
+void SCRegressor::fillSC ( const edm::Event& iEvent, const edm::EventSetup& iSetup )
+{
+
+  edm::Handle<EcalRecHitCollection> EBRecHitsH;
+  iEvent.getByToken(EBRecHitCollectionT_, EBRecHitsH);
+
+  edm::ESHandle<CaloGeometry> caloGeomH;
+  iSetup.get<CaloGeometryRecord>().get(caloGeomH);
+  const CaloGeometry* caloGeom = caloGeomH.product();
+
+  for(int iPho (0); iPho < nPhotons; iPho++) {
+    vSC_energy_[iPho].assign(crop_size*crop_size,0.);
+    vSC_energyT_[iPho].assign(crop_size*crop_size,0.);
+    vSC_energyZ_[iPho].assign(crop_size*crop_size,0.);
+    vSC_time_[iPho].assign(crop_size*crop_size,0.);
+  }
+
+  int iphi_, ieta_, idx_; // rows:ieta, cols:iphi
+  int iphi_shift, ieta_shift;
+  int iphi_crop, ieta_crop;
+  for(EcalRecHitCollection::const_iterator iRHit = EBRecHitsH->begin();
+      iRHit != EBRecHitsH->end();
+      ++iRHit) {
+
+    if ( iRHit->energy() < zs ) continue;
+
+    // Convert detector coordinates to ordinals
+    EBDetId ebId( iRHit->id() );
+    iphi_ = ebId.iphi()-1; // [0,...,359]
+    ieta_ = ebId.ieta() > 0 ? ebId.ieta()-1 : ebId.ieta(); // [-85,...,-1,0,...,84]
+    ieta_ += EBDetId::MAX_IETA; // [0,...,169]
+
+    for ( unsigned iP(0); iP < nPhotons; iP++ ) {
+
+      iphi_shift = vIphi_Emax[iP] - 15;
+      ieta_shift = vIeta_Emax[iP] - 15;
+      //std::cout << " >> Storing: iphi_Emax,ieta_Emax: " << vIphi_Emax[iP] << ", " << vIeta_Emax[iP] << std::endl;
+
+      // Convert to [0,...,31][0,...,31]
+      ieta_crop = ieta_ - ieta_shift;
+      iphi_crop = iphi_ - iphi_shift;
+      if ( iphi_crop >= EBDetId::MAX_IPHI ) iphi_crop = iphi_crop - EBDetId::MAX_IPHI; // get wrap-around hits
+
+      if ( ieta_crop < 0 || ieta_crop > crop_size-1 ) continue;
+      if ( iphi_crop < 0 || iphi_crop > crop_size-1 ) continue;
+      
+      // Convert to [0,...,32*32-1] 
+      idx_ = ieta_crop*crop_size + iphi_crop;
+
+      // Cell geometry provides access to (rho,eta,phi) coordinates of cell center
+      //auto cell = caloGeom->getGeometry(ebId);
+      auto pos = caloGeom->getPosition(ebId);
+      
+      // Fill branch arrays 
+      vSC_energy_[iP][idx_] = iRHit->energy();
+      //vSC_energyT_[iP][idx_] = iRHit->energy()/TMath::CosH(vPho_eta_[iP]);
+      vSC_energyT_[iP][idx_] = iRHit->energy()/TMath::CosH(pos.eta());
+      vSC_energyZ_[iP][idx_] = iRHit->energy()*std::abs(TMath::TanH(pos.eta()));
+      vSC_time_[iP][idx_] = iRHit->time();
+      /*
+      vEB_SCenergy_[ebId.hashedIndex()] = iRHit->energy();
+      */
+      //std::cout << " >> " << iP << ": iphi_,ieta_,E: " << iphi_crop << ", " << ieta_crop << ", " << iRHit->energy() << std::endl; 
+
+      // Fill histograms to monitor cumulative distributions
+      hSC_energy[iP]->Fill( iphi_crop,ieta_crop,iRHit->energy() );
+      hSC_time[iP]->Fill( iphi_crop,ieta_crop,iRHit->time() );
+
+    } // photons
+  } // EB rechits
+
+} // fillSC()

--- a/RecHitAnalyzer/plugins/SCRegressor_fillSC.cc
+++ b/RecHitAnalyzer/plugins/SCRegressor_fillSC.cc
@@ -48,9 +48,9 @@ void SCRegressor::fillSC ( const edm::Event& iEvent, const edm::EventSetup& iSet
   int iphi_crop, ieta_crop;
   for ( unsigned int iP(0); iP < nPho; iP++ ) {
 
-    iphi_shift = vIphi_Emax[iP] - 15;
-    ieta_shift = vIeta_Emax[iP] - 15;
-    if ( debug ) std::cout << " >> Doing pho img: iphi_Emax,ieta_Emax: " << vIphi_Emax[iP] << ", " << vIeta_Emax[iP] << std::endl;
+    iphi_shift = vIphi_Emax_[iP] - 15;
+    ieta_shift = vIeta_Emax_[iP] - 15;
+    if ( debug ) std::cout << " >> Doing pho img: iphi_Emax,ieta_Emax: " << vIphi_Emax_[iP] << ", " << vIeta_Emax_[iP] << std::endl;
 
     for(EcalRecHitCollection::const_iterator iRHit = EBRecHitsH->begin();
         iRHit != EBRecHitsH->end();

--- a/RecHitAnalyzer/plugins/SCRegressor_fillSC.cc
+++ b/RecHitAnalyzer/plugins/SCRegressor_fillSC.cc
@@ -3,29 +3,18 @@
 // Initialize branches _____________________________________________________//
 void SCRegressor::branchesSC ( TTree* tree, edm::Service<TFileService> &fs )
 {
-  char hname[50], htitle[50];
-  for(int iPho (0); iPho < nPhotons; iPho++) {
-    sprintf(hname, "SC_energy%d",iPho);
-    sprintf(htitle,"E(i#phi,i#eta);iphi;ieta");
-    hSC_energy[iPho] = fs->make<TH2D>(hname, htitle,
-        crop_size, 0, crop_size,
-        crop_size, 0, crop_size );
-    sprintf(hname, "SC_time%d",iPho);
-    sprintf(htitle,"t(i#phi,i#eta);iphi;ieta");
-    hSC_time[iPho] = fs->make<TH2D>(hname, htitle,
-        crop_size, 0, crop_size,
-        crop_size, 0, crop_size );
-  }
-  for(int iPho (0); iPho < nPhotons; iPho++) {
-    sprintf(hname, "SC_energy%d",iPho);
-    RHTree->Branch(hname,          &vSC_energy_[iPho]);
-    sprintf(hname, "SC_energyT%d",iPho);
-    RHTree->Branch(hname,          &vSC_energyT_[iPho]);
-    sprintf(hname, "SC_energyZ%d",iPho);
-    RHTree->Branch(hname,          &vSC_energyZ_[iPho]);
-    sprintf(hname, "SC_time%d",iPho);
-    RHTree->Branch(hname,          &vSC_time_[iPho]);
-  }
+  hSC_energy = fs->make<TProfile2D>("SC_energy", "E(i#phi,i#eta);iphi;ieta",
+      crop_size, 0, crop_size,
+      crop_size, 0, crop_size );
+  hSC_time = fs->make<TProfile2D>("SC_time", "t(i#phi,i#eta);iphi;ieta",
+      crop_size, 0, crop_size,
+      crop_size, 0, crop_size );
+
+  RHTree->Branch("SC_energy",  &vSC_energy_);
+  RHTree->Branch("SC_energyT", &vSC_energyT_);
+  RHTree->Branch("SC_energyZ", &vSC_energyZ_);
+  RHTree->Branch("SC_time",    &vSC_time_);
+
 } // branchesSC()
 
 // Fill SC rechits _________________________________________________________________//
@@ -39,33 +28,41 @@ void SCRegressor::fillSC ( const edm::Event& iEvent, const edm::EventSetup& iSet
   iSetup.get<CaloGeometryRecord>().get(caloGeomH);
   const CaloGeometry* caloGeom = caloGeomH.product();
 
-  for(int iPho (0); iPho < nPhotons; iPho++) {
-    vSC_energy_[iPho].assign(crop_size*crop_size,0.);
-    vSC_energyT_[iPho].assign(crop_size*crop_size,0.);
-    vSC_energyZ_[iPho].assign(crop_size*crop_size,0.);
-    vSC_time_[iPho].assign(crop_size*crop_size,0.);
+  vSC_energy_.clear();
+  vSC_energyT_.clear();
+  vSC_energyZ_.clear();
+  vSC_time_.clear();
+  std::vector<float> SC_energy;
+  std::vector<float> SC_energyT;
+  std::vector<float> SC_energyZ;
+  std::vector<float> SC_time;
+  for ( unsigned int iP = 0; iP < nPho; iP++ ) { 
+    SC_energy.assign(crop_size*crop_size,0.);
+    SC_energyT.assign(crop_size*crop_size,0.);
+    SC_energyZ.assign(crop_size*crop_size,0.);
+    SC_time.assign(crop_size*crop_size,0.);
   }
 
   int iphi_, ieta_, idx_; // rows:ieta, cols:iphi
   int iphi_shift, ieta_shift;
   int iphi_crop, ieta_crop;
-  for(EcalRecHitCollection::const_iterator iRHit = EBRecHitsH->begin();
-      iRHit != EBRecHitsH->end();
-      ++iRHit) {
+  for ( unsigned int iP(0); iP < nPho; iP++ ) {
 
-    if ( iRHit->energy() < zs ) continue;
+    iphi_shift = vIphi_Emax[iP] - 15;
+    ieta_shift = vIeta_Emax[iP] - 15;
+    if ( debug ) std::cout << " >> Doing pho img: iphi_Emax,ieta_Emax: " << vIphi_Emax[iP] << ", " << vIeta_Emax[iP] << std::endl;
 
-    // Convert detector coordinates to ordinals
-    EBDetId ebId( iRHit->id() );
-    iphi_ = ebId.iphi()-1; // [0,...,359]
-    ieta_ = ebId.ieta() > 0 ? ebId.ieta()-1 : ebId.ieta(); // [-85,...,-1,0,...,84]
-    ieta_ += EBDetId::MAX_IETA; // [0,...,169]
+    for(EcalRecHitCollection::const_iterator iRHit = EBRecHitsH->begin();
+        iRHit != EBRecHitsH->end();
+        ++iRHit) {
 
-    for ( unsigned iP(0); iP < nPhotons; iP++ ) {
+      if ( iRHit->energy() < zs ) continue;
 
-      iphi_shift = vIphi_Emax[iP] - 15;
-      ieta_shift = vIeta_Emax[iP] - 15;
-      //std::cout << " >> Storing: iphi_Emax,ieta_Emax: " << vIphi_Emax[iP] << ", " << vIeta_Emax[iP] << std::endl;
+      // Convert detector coordinates to ordinals
+      EBDetId ebId( iRHit->id() );
+      iphi_ = ebId.iphi()-1; // [0,...,359]
+      ieta_ = ebId.ieta() > 0 ? ebId.ieta()-1 : ebId.ieta(); // [-85,...,-1,0,...,84]
+      ieta_ += EBDetId::MAX_IETA; // [0,...,169]
 
       // Convert to [0,...,31][0,...,31]
       ieta_crop = ieta_ - ieta_shift;
@@ -83,21 +80,26 @@ void SCRegressor::fillSC ( const edm::Event& iEvent, const edm::EventSetup& iSet
       auto pos = caloGeom->getPosition(ebId);
       
       // Fill branch arrays 
-      vSC_energy_[iP][idx_] = iRHit->energy();
-      //vSC_energyT_[iP][idx_] = iRHit->energy()/TMath::CosH(vPho_eta_[iP]);
-      vSC_energyT_[iP][idx_] = iRHit->energy()/TMath::CosH(pos.eta());
-      vSC_energyZ_[iP][idx_] = iRHit->energy()*std::abs(TMath::TanH(pos.eta()));
-      vSC_time_[iP][idx_] = iRHit->time();
+      SC_energy[idx_] = iRHit->energy();
+      //SC_energyT[idx_] = iRHit->energy()/TMath::CosH(vPho_eta_);
+      SC_energyT[idx_] = iRHit->energy()/TMath::CosH(pos.eta());
+      SC_energyZ[idx_] = iRHit->energy()*std::abs(TMath::TanH(pos.eta()));
+      SC_time[idx_] = iRHit->time();
       /*
       vEB_SCenergy_[ebId.hashedIndex()] = iRHit->energy();
       */
       //std::cout << " >> " << iP << ": iphi_,ieta_,E: " << iphi_crop << ", " << ieta_crop << ", " << iRHit->energy() << std::endl; 
 
       // Fill histograms to monitor cumulative distributions
-      hSC_energy[iP]->Fill( iphi_crop,ieta_crop,iRHit->energy() );
-      hSC_time[iP]->Fill( iphi_crop,ieta_crop,iRHit->time() );
+      hSC_energy->Fill( iphi_crop,ieta_crop,iRHit->energy() );
+      hSC_time->Fill( iphi_crop,ieta_crop,iRHit->time() );
 
-    } // photons
-  } // EB rechits
+    } // EB rechits
+    vSC_energy_.push_back( SC_energy );
+    vSC_energyT_.push_back( SC_energyT );
+    vSC_energyZ_.push_back( SC_energyZ );
+    vSC_time_.push_back( SC_time );
+
+  } // photons
 
 } // fillSC()

--- a/RecHitAnalyzer/plugins/SCRegressor_runPhoSel.cc
+++ b/RecHitAnalyzer/plugins/SCRegressor_runPhoSel.cc
@@ -1,0 +1,253 @@
+#include "MLAnalyzer/RecHitAnalyzer/interface/SCRegressor.h"
+
+const math::XYZTLorentzVector getFinalP4( const reco::Candidate* phoCand ) {
+  if ( phoCand->status() == 1 ) {
+    return phoCand->p4();
+  } else {
+    if ( phoCand->numberOfDaughters() == 1 )
+      return getFinalP4( phoCand->daughter(0) );
+    else
+      return phoCand->p4();
+  }
+}
+
+// Initialize branches _____________________________________________________//
+void SCRegressor::branchesPhoSel ( TTree* tree, edm::Service<TFileService> &fs )
+{
+  hSC_mass = fs->make<TH1F>("SC_mass", "m_{SC};m_{SC}",50, 0., 0.5);
+  hDR = fs->make<TH1F>("DR_seed_subJet", "#DeltaR(seed,subJet);#DeltaR",50, 0., 50.*0.0174);
+  hdEta = fs->make<TH1F>("dEta_seed_subJet", "#Delta#eta(seed,subJet);#Delta#eta",50, 0., 50.*0.0174);
+  hdPhi = fs->make<TH1F>("dPhi_seed_subJet", "#Delta#phi(seed,subJet);#Delta#phi",50, 0., 50.*0.0174);
+  hdPhidEta = fs->make<TH3F>("dPhidEta_GG", "#Delta(#phi,#eta,m);#Delta#phi(#gamma,#gamma);#Delta#eta(#gamma,#gamma);m",6, 0., 6.*0.0174, 6, 0., 6.*0.0174, 16., 0.,1.6);
+  hPt = fs->make<TH1F>("Pt", "Pt", 65, 30., 160.);
+
+  char hname[50];
+  for(int iPho (0); iPho < nPhotons; iPho++) {
+    sprintf(hname, "SC_mass%d",iPho);
+    RHTree->Branch(hname,          &vSC_mass_[iPho]);
+    sprintf(hname, "SC_DR%d",iPho);
+    RHTree->Branch(hname,          &vSC_DR_[iPho]);
+    sprintf(hname, "SC_pT%d",iPho);
+    RHTree->Branch(hname,          &vSC_pT_[iPho]);
+    sprintf(hname, "pho_pT%d",iPho);
+    RHTree->Branch(hname,      &vPho_pT_[iPho]);
+    sprintf(hname, "pho_E%d",iPho);
+    RHTree->Branch(hname,      &vPho_E_[iPho]);
+    sprintf(hname, "pho_eta%d",iPho);
+    RHTree->Branch(hname,      &vPho_eta_[iPho]);
+    sprintf(hname, "pho_phi%d",iPho);
+    RHTree->Branch(hname,      &vPho_phi_[iPho]);
+    sprintf(hname, "pho_r9%d",iPho);
+    RHTree->Branch(hname,      &vPho_r9_[iPho]);
+    sprintf(hname, "pho_sieie%d",iPho);
+    RHTree->Branch(hname,      &vPho_sieie_[iPho]);
+  }
+
+  hnPho = fs->make<TH2F>("nPho", "N(m_{#pi},p_{T,#pi})_{reco};m_{#pi^{0}};p_{T,#pi^0}",
+      16, 0., 1.6, 17, 15., 100.);
+}
+
+// Run event selection ___________________________________________________________________//
+bool SCRegressor::runPhoSel ( const edm::Event& iEvent, const edm::EventSetup& iSetup ) {
+
+  edm::Handle<reco::PhotonCollection> photons;
+  iEvent.getByToken(photonCollectionT_, photons);
+
+  edm::Handle<reco::GenParticleCollection> genParticles;
+  iEvent.getByToken(genParticleCollectionT_, genParticles);
+
+  //std::vector<int> vGenPi0Idxs_;
+  vGenPi0Idxs_.clear();
+
+  // ____________ Gen-level studies ________________ //
+  int nPi0 = 0;
+  float dR;
+  //std::vector<math::PtEtaPhiELorentzVectorD> vPhoPairs[nPhotons];
+  //std::vector<math::XYZTLorentzVector> vPhoPairs[nPhotons];
+  std::map<unsigned int, std::vector<unsigned int>> mGenPi0_RecoPho;
+  for ( unsigned int iG = 0; iG < genParticles->size(); iG++ ) {
+
+    reco::GenParticleRef iGen( genParticles, iG );
+    // ID cuts
+    if ( debug ) std::cout << " >> pdgId:"<< iGen->pdgId() << " status:" << iGen->status() << " nDaughters:" << iGen->numberOfDaughters() << std::endl;
+    if ( std::abs(iGen->pdgId()) != 111 ) continue;
+    if ( debug ) std::cout << " >> pdgId:111 nDaughters:" << iGen->numberOfDaughters() << std::endl;
+    if ( iGen->numberOfDaughters() != 2 ) continue;
+    //if ( iGen->mass() > 0.4 ) continue;
+    dR = reco::deltaR( iGen->daughter(0)->eta(),iGen->daughter(0)->phi(), iGen->daughter(1)->eta(),iGen->daughter(1)->phi() );
+    if ( dR > 5*.0174 ) continue;
+
+    vGenPi0Idxs_.push_back( iG );
+    mGenPi0_RecoPho.insert( std::pair<unsigned int, std::vector<unsigned int>>(iG, std::vector<unsigned int>()) );
+    nPi0++;
+
+  } // genParticle loop: count good photons
+  if ( debug ) std::cout << " >> mGenPi0.size: " << mGenPi0_RecoPho.size() << std::endl;
+
+  if ( nPi0 != nPhotons ) return false;
+
+  ////////// Apply selection //////////
+
+  //float ptCut = 45., etaCut = 1.44;
+  float ptCut = 15., etaCut = 1.44;
+
+  // Get reco (pT>5GeV) photons associated to pi0
+  float minDR = 100.;
+  int minDR_idx = -1;
+  // Loop over pi0s
+  for ( auto& mG : mGenPi0_RecoPho ) {
+
+    reco::GenParticleRef iGen( genParticles, mG.first );
+
+    if ( debug ) std::cout << " >> pi0[" << mG.first << "]"<< std::endl;
+    // Loop over photons from pi0
+    for ( unsigned int iD = 0; iD < iGen->numberOfDaughters(); iD++ ) {
+
+      const reco::Candidate* iGenPho = iGen->daughter(iD);
+
+      // Loop over reco photon collection
+      minDR = 100.;
+      minDR_idx = -1;
+      if ( debug ) std::cout << "  >> iD[" << iD << "]" << std::endl;
+      for ( unsigned int iP = 0; iP < photons->size(); iP++ ) {
+
+        reco::PhotonRef iPho( photons, iP );
+        if ( iPho->pt() < 5. ) continue;
+        dR = reco::deltaR( iPho->eta(),iPho->phi(), iGenPho->eta(),iGenPho->phi() );
+        if ( dR > minDR ) continue;
+
+        minDR = dR;
+        minDR_idx = iP;
+        if ( debug ) std::cout << "   >> minDR_idx:" << minDR_idx << " " << minDR << std::endl;
+
+      } // reco photons
+      if ( minDR > 0.04 ) continue;
+      //mG[mG.first].push_back( minDR_idx );
+      mG.second.push_back( minDR_idx );
+      if ( debug ) std::cout << "   >> !minDR_idx:" << minDR_idx << std::endl;
+
+    } // gen photons 
+    dR = reco::deltaR( iGen->daughter(0)->eta(),iGen->daughter(0)->phi(), iGen->daughter(1)->eta(),iGen->daughter(1)->phi() );
+    if ( debug ) std::cout << "   >> gen dR:" << dR << std::endl;
+
+  } // gen pi0s
+
+  // Ensure only 1 reco photon associated to each gen pi0
+  std::vector<int> vRecoPhoIdxs_;
+  for ( auto const& mG : mGenPi0_RecoPho ) {
+    if ( debug ) std::cout << " >> pi0[" << mG.first << "] size:" << mG.second.size() << std::endl; 
+    // Possibilities:
+    // 1) pho_gen1: unmatched, pho_gen2: unmatched => both reco pho failed pT cut or dR matching, reject
+    // 2) pho_gen1: reco-matched1, pho_gen1: unmatched => one reco pho failed pT cut or dR matching, can accept
+    // 3) pho_gen1: reco-matched1, pho_gen2: reco-matched2
+    //    3a) reco-matched1 == reco-matched2 => merged, accept
+    //    3b) reco-matched1 != reco-matched2 => resolved, reject
+    if ( mG.second.size() == 0 ) {
+      //mGenPi0_RecoPho.erase( mG.first );
+      continue;
+    }
+    if ( mG.second.size() == 2 && mG.second[0] != mG.second[1] ) {
+      //mGenPi0_RecoPho.erase( mG.first );
+      continue; // 2 resolved reco photons 
+    }
+    vRecoPhoIdxs_.push_back( mG.second[0] );
+  } 
+  if ( debug ) std::cout << " >> RecoPhos.size: " << vRecoPhoIdxs_.size() << std::endl;
+  if ( debug ) std::cout << " >> mGenPi0.size: " << mGenPi0_RecoPho.size() << std::endl;
+
+  // Ensure each of pi0-matched reco photons passes pre-selection
+  // NOTE: at this point there is 1-1 correspondence between pi0 and reco pho,
+  // so suffices to check there are as many pre-selected phos as pi0s
+  bool isIso;
+  vPreselPhoIdxs_.clear();
+  if ( debug ) std::cout << " >> PhoCol.size: " << photons->size() << std::endl;
+  for ( unsigned int i = 0; i < vRecoPhoIdxs_.size(); i++ ) {
+
+    reco::PhotonRef iPho( photons, vRecoPhoIdxs_[i] );
+
+    if ( iPho->pt() < ptCut ) continue;
+    if ( std::abs(iPho->eta()) > etaCut ) continue;
+    if ( debug ) std::cout << " >> pT: " << iPho->pt() << " eta: " << iPho->eta() << std::endl;
+    if ( iPho->r9() < 0.5 ) continue;
+    if ( iPho->hadTowOverEm() > 0.07 ) continue;
+    if ( iPho->full5x5_sigmaIetaIeta() > 0.0105 ) continue;
+    if ( iPho->hasPixelSeed() == true ) continue;
+
+    // Ensure pre-sel photons are isolated 
+    isIso = true;
+    for ( unsigned int j = 0; j < vRecoPhoIdxs_.size(); j++ ) {
+
+      if ( i == j ) continue;
+      reco::PhotonRef jPho( photons, vRecoPhoIdxs_[j] ); 
+      dR = reco::deltaR( iPho->eta(),iPho->phi(), jPho->eta(),jPho->phi() );
+      if ( debug ) std::cout << "   >> reco dR:" << dR << std::endl;
+      if ( dR > 12*.0174 ) continue;
+      isIso = false;
+      break;
+
+    } // reco photon j
+    if ( !isIso ) continue;
+
+    vPreselPhoIdxs_.push_back( vRecoPhoIdxs_[i] );
+
+  } // reco photon i
+  if ( debug ) std::cout << " >> PreSelPhos.size: " << vRecoPhoIdxs_.size() << std::endl;
+
+  if ( vPreselPhoIdxs_.size() != nPhotons ) return false;
+  //TODO: allow variable number of pre-selected photons to be saved per event
+  //TODO: get rid of gen pi0s which are not regressed
+
+  if ( debug ) std::cout << " >> Passed selection. " << std::endl;
+  return true;
+}
+
+// Fill branches ___________________________________________________________________//
+void SCRegressor::fillPhoSel ( const edm::Event& iEvent, const edm::EventSetup& iSetup )
+{
+  edm::Handle<reco::PhotonCollection> photons;
+  iEvent.getByToken(photonCollectionT_, photons);
+
+  ////////// Store each shower crop //////////
+  for ( unsigned int i = 0; i < vRegressPhoIdxs_.size(); i++ ) {
+    reco::PhotonRef iPho( photons, vRegressPhoIdxs_[i] );
+    // Fill branch arrays
+    vPho_pT_[i] = iPho->pt();
+    vPho_E_[i] = iPho->energy();
+    vPho_eta_[i] = iPho->eta();
+    vPho_phi_[i] = iPho->phi();
+    //std::cout << "r9: " << iPho->r9() << std::endl;
+    vPho_r9_[i] = iPho->r9();
+    vPho_sieie_[i] = iPho->full5x5_sigmaIetaIeta(); 
+  } // photons
+
+  edm::Handle<reco::GenParticleCollection> genParticles;
+  iEvent.getByToken(genParticleCollectionT_, genParticles);
+
+  float dEta, dPhi, dR, mPi0, ptPi0;
+  //for ( int i = 0; i < nPi0; i++ ) {
+  for ( unsigned int i = 0; i < vGenPi0Idxs_.size(); i++ ) {
+    reco::GenParticleRef iGen( genParticles, vGenPi0Idxs_[i] );
+    //mPi0 = (vPhoPairs[i][0] + vPhoPairs[i][1]).mass();
+    //dR = reco::deltaR( vPhoPairs[i][0].eta(),vPhoPairs[i][0].phi(), vPhoPairs[i][1].eta(),vPhoPairs[i][1].phi() );
+    //dEta = std::abs( vPhoPairs[i][0].eta() - vPhoPairs[i][1].eta() );
+    //dPhi = reco::deltaPhi( vPhoPairs[i][0].phi(), vPhoPairs[i][1].phi() );
+    mPi0 = iGen->mass();
+    ptPi0 = iGen->pt();
+
+    dR = reco::deltaR( iGen->daughter(0)->eta(),iGen->daughter(0)->phi(), iGen->daughter(1)->eta(),iGen->daughter(1)->phi() );
+    dEta = std::abs( iGen->daughter(0)->eta() - iGen->daughter(1)->eta() );
+    dPhi = reco::deltaPhi( iGen->daughter(0)->phi(), iGen->daughter(1)->phi() );
+
+    if ( debug ) std::cout << " >> m0:" << mPi0 << " dR:" << dR << " dPhi:" << dPhi << std::endl;
+    vSC_DR_[i] = dR;
+    vSC_pT_[i] = iGen->pt(); 
+    vSC_mass_[i] = mPi0;
+
+    hPt->Fill( ptPi0 );
+    hdPhidEta->Fill( dPhi, dEta, mPi0 );
+    //hnPho->Fill( mPi0, iGen->pt() );
+    hnPho->Fill( mPi0, ptPi0 );
+    hSC_mass->Fill( mPi0 );
+  }
+
+}

--- a/RecHitAnalyzer/plugins/SCRegressor_runPhoSel.cc
+++ b/RecHitAnalyzer/plugins/SCRegressor_runPhoSel.cc
@@ -46,9 +46,10 @@ bool SCRegressor::runPhoSel ( const edm::Event& iEvent, const edm::EventSetup& i
     if ( std::abs(iGen->pdgId()) != 111 ) continue;
     if ( debug ) std::cout << " >> pdgId:111 nDaughters:" << iGen->numberOfDaughters() << std::endl;
     if ( iGen->numberOfDaughters() != 2 ) continue;
-    //if ( iGen->mass() > 0.4 ) continue;
+    ///*
     dR = reco::deltaR( iGen->daughter(0)->eta(),iGen->daughter(0)->phi(), iGen->daughter(1)->eta(),iGen->daughter(1)->phi() );
-    if ( dR > 5*.0174 ) continue;
+    if ( dR > 10*.0174 ) continue;
+    //*/
 
     mGenPi0_RecoPho.insert( std::pair<unsigned int, std::vector<unsigned int>>(iG, std::vector<unsigned int>()) );
 
@@ -136,6 +137,7 @@ bool SCRegressor::runPhoSel ( const edm::Event& iEvent, const edm::EventSetup& i
     if ( iPho->full5x5_sigmaIetaIeta() > 0.0105 ) continue;
     if ( iPho->hasPixelSeed() == true ) continue;
 
+    ///*
     // Ensure pre-sel photons are isolated 
     isIso = true;
     for ( unsigned int j = 0; j < vRecoPhoIdxs_.size(); j++ ) {
@@ -144,12 +146,13 @@ bool SCRegressor::runPhoSel ( const edm::Event& iEvent, const edm::EventSetup& i
       reco::PhotonRef jPho( photons, vRecoPhoIdxs_[j] ); 
       dR = reco::deltaR( iPho->eta(),iPho->phi(), jPho->eta(),jPho->phi() );
       if ( debug ) std::cout << "   >> reco dR:" << dR << std::endl;
-      if ( dR > 12*.0174 ) continue;
+      if ( dR > 16*.0174 ) continue;
       isIso = false;
       break;
 
     } // reco photon j
     if ( !isIso ) continue;
+    //*/
 
     vPreselPhoIdxs_.push_back( vRecoPhoIdxs_[i] );
 

--- a/RecHitAnalyzer/plugins/SCRegressor_runPhoSel_gamma.cc
+++ b/RecHitAnalyzer/plugins/SCRegressor_runPhoSel_gamma.cc
@@ -1,0 +1,180 @@
+#include "MLAnalyzer/RecHitAnalyzer/interface/SCRegressor.h"
+
+// Initialize branches _____________________________________________________//
+void SCRegressor::branchesPhoSel_gamma ( TTree* tree, edm::Service<TFileService> &fs )
+{
+  hSC_pT = fs->make<TH1F>("SC_pT", "Pt", 27, 15., 150.);
+
+  RHTree->Branch("SC_mass",   &vSC_mass_);
+  RHTree->Branch("SC_DR",     &vSC_DR_);
+  RHTree->Branch("SC_pT",     &vSC_pT_);
+
+  RHTree->Branch("pho_pT",    &vPho_pT_);
+  RHTree->Branch("pho_E",     &vPho_E_);
+  RHTree->Branch("pho_eta",   &vPho_eta_);
+  RHTree->Branch("pho_phi",   &vPho_phi_);
+  RHTree->Branch("pho_r9",    &vPho_r9_);
+  RHTree->Branch("pho_sieie", &vPho_sieie_);
+
+}
+
+// Run event selection ___________________________________________________________________//
+bool SCRegressor::runPhoSel_gamma ( const edm::Event& iEvent, const edm::EventSetup& iSetup ) {
+
+  edm::Handle<reco::GenParticleCollection> genParticles;
+  iEvent.getByToken(genParticleCollectionT_, genParticles);
+
+  edm::Handle<reco::PhotonCollection> photons;
+  iEvent.getByToken(photonCollectionT_, photons);
+
+  // Get reco (pT>5GeV) photons associated to gen photons
+  float dR;
+  float minDR = 100.;
+  int minDR_idx = -1;
+  mGenPi0_RecoPho.clear();
+  for ( unsigned int iG = 0; iG < genParticles->size(); iG++ ) {
+
+    reco::GenParticleRef iGen( genParticles, iG );
+
+    if ( iGen->pdgId() != 22 ) continue;
+    if ( iGen->status() != 1 ) continue;
+
+    mGenPi0_RecoPho.insert( std::pair<unsigned int, std::vector<unsigned int>>(iG, std::vector<unsigned int>()) );
+
+    // Loop over reco photon collection
+    minDR = 100.;
+    minDR_idx = -1;
+    for ( unsigned int iP = 0; iP < photons->size(); iP++ ) {
+
+      reco::PhotonRef iPho( photons, iP );
+      if ( iPho->pt() < 5. ) continue;
+      dR = reco::deltaR( iPho->eta(),iPho->phi(), iGen->eta(),iGen->phi() );
+      if ( dR > minDR ) continue;
+
+      minDR = dR;
+      minDR_idx = iP;
+      if ( debug ) std::cout << "   >> minDR_idx:" << minDR_idx << " " << minDR << std::endl;
+
+    } // reco photons
+    if ( minDR > 0.04 ) continue;
+    mGenPi0_RecoPho[iG].push_back( minDR_idx );
+    if ( debug ) std::cout << "   >> !minDR_idx:" << minDR_idx << std::endl;
+
+  } // gen photons
+
+  ////////// Apply selection //////////
+
+  float ptCut = 15., etaCut = 1.44;
+
+  if ( debug ) std::cout << " >> PhoCol.size: " << photons->size() << std::endl;
+  // Ensure only 1 reco photon associated to each gen pho 
+  std::vector<int> vRecoPhoIdxs_;
+  for ( auto const& mG : mGenPi0_RecoPho ) {
+    if ( mG.second.empty() ) continue;
+    if ( mG.second.size() != 1 ) continue;
+    vRecoPhoIdxs_.push_back( mG.second[0] );
+  }
+  if ( debug ) std::cout << " >> RecoPhos.size: " << vRecoPhoIdxs_.size() << std::endl;
+  if ( vRecoPhoIdxs_.empty() ) return false;
+
+  // Ensure each pre-selected photon is isolated
+  bool isIso;
+  vPreselPhoIdxs_.clear();
+  for ( unsigned int i = 0; i < vRecoPhoIdxs_.size(); i++ ) {
+
+    reco::PhotonRef iPho( photons, vRecoPhoIdxs_[i] );
+
+    if ( iPho->pt() < ptCut ) continue;
+    if ( std::abs(iPho->eta()) > etaCut ) continue;
+    if ( debug ) std::cout << " >> pT: " << iPho->pt() << " eta: " << iPho->eta() << std::endl;
+    if ( iPho->r9() < 0.5 ) continue;
+    if ( iPho->hadTowOverEm() > 0.07 ) continue;
+    if ( iPho->full5x5_sigmaIetaIeta() > 0.0105 ) continue;
+    if ( iPho->hasPixelSeed() == true ) continue;
+
+    ///*
+    // Ensure pre-sel photons are isolated 
+    isIso = true;
+    for ( unsigned int j = 0; j < vRecoPhoIdxs_.size(); j++ ) {
+
+      if ( i == j ) continue;
+      reco::PhotonRef jPho( photons, vRecoPhoIdxs_[j] ); 
+      dR = reco::deltaR( iPho->eta(),iPho->phi(), jPho->eta(),jPho->phi() );
+      if ( debug ) std::cout << "   >> reco dR:" << dR << std::endl;
+      if ( dR > 16*.0174 ) continue;
+      isIso = false;
+      break;
+
+    } // reco photon j
+    if ( !isIso ) continue;
+    //*/
+
+    vPreselPhoIdxs_.push_back( vRecoPhoIdxs_[i] );
+
+  } // reco photon i
+  if ( debug ) std::cout << " >> PreselPhos.size: " << vPreselPhoIdxs_.size() << std::endl;
+  if ( vPreselPhoIdxs_.empty() ) return false;
+
+  if ( debug ) std::cout << " >> Passed selection. " << std::endl;
+  return true;
+}
+
+// Fill branches ___________________________________________________________________//
+void SCRegressor::fillPhoSel_gamma ( const edm::Event& iEvent, const edm::EventSetup& iSetup )
+{
+  edm::Handle<reco::PhotonCollection> photons;
+  iEvent.getByToken(photonCollectionT_, photons);
+
+  edm::Handle<reco::GenParticleCollection> genParticles;
+  iEvent.getByToken(genParticleCollectionT_, genParticles);
+
+  // Eliminate gen pi0s which are unmatched
+  for ( auto const& mG : mGenPi0_RecoPho ) {
+    if ( mG.second.empty() ) {
+      mGenPi0_RecoPho.erase( mG.first );
+      continue;
+    }
+    if ( std::find(vRegressPhoIdxs_.begin(), vRegressPhoIdxs_.end(), mG.second[0]) == vRegressPhoIdxs_.end() )
+      mGenPi0_RecoPho.erase( mG.first );
+  }
+  if ( debug ) std::cout << " >> mGenPi0.size: " << mGenPi0_RecoPho.size() << std::endl;
+
+  if ( debug ) {
+    int iter_idx = 0;
+    for ( auto const& mG : mGenPi0_RecoPho ) {
+      std::cout << " >> mGenPi0_RecoPho[" << mG.first << "]: " << mG.second[0] << " vs. " << vRegressPhoIdxs_[iter_idx] << std::endl;
+      iter_idx++;
+    }
+  }
+
+  ////////// Store kinematics //////////
+  vPho_pT_.clear();
+  vPho_E_.clear();
+  vPho_eta_.clear();
+  vPho_phi_.clear();
+  vPho_r9_.clear();
+  vPho_sieie_.clear();
+  for ( auto const& mG : mGenPi0_RecoPho ) {
+    reco::PhotonRef iPho( photons, mG.second[0] );
+    // Fill branch arrays
+    vPho_pT_.push_back( iPho->pt() );
+    vPho_E_.push_back( iPho->energy() );
+    vPho_eta_.push_back( iPho->eta() );
+    vPho_phi_.push_back( iPho->phi() );
+    vPho_r9_.push_back( iPho->r9() );
+    vPho_sieie_.push_back( iPho->full5x5_sigmaIetaIeta() );
+  } // photons
+
+  vSC_DR_.clear();
+  vSC_pT_.clear();
+  vSC_mass_.clear();
+  for ( auto const& mG : mGenPi0_RecoPho ) {
+    reco::GenParticleRef iGen( genParticles, mG.first );
+    vSC_DR_.push_back( 0. );
+    vSC_pT_.push_back( iGen->pt() ); 
+    vSC_mass_.push_back( 0. );
+
+    hSC_pT->Fill( iGen->pt() );
+  }
+
+}

--- a/convert_root2pq_EBshower.py
+++ b/convert_root2pq_EBshower.py
@@ -1,0 +1,121 @@
+import pyarrow.parquet as pq
+import pyarrow as pa
+import ROOT
+import numpy as np
+import glob, os
+
+import argparse
+parser = argparse.ArgumentParser(description='Process some integers.')
+parser.add_argument('-i', '--infile', required=True, type=str, help='Input root file.')
+parser.add_argument('-o', '--outdir', required=True, type=str, help='Output pq file dir.')
+parser.add_argument('-d', '--decay', required=True, type=str, help='Decay name.')
+parser.add_argument('-n', '--idx', required=True, type=int, help='Input root file index.')
+parser.add_argument('-w', '--wgt_file', default='', type=str, help='Weight file.')
+args = parser.parse_args()
+
+def get_weight_2d(m0, pt, m0_edges, pt_edges, wgts):
+    idx_m0 = np.argmax(m0 <= m0_edges)-1
+    idx_pt = np.argmax(pt <= pt_edges)-1
+    #print(idx_m0, idx_pt)
+    return wgts[idx_m0, idx_pt]
+
+w = np.load(args.wgt_file)
+hmvpt, m_edges, pt_edges = w['mvpt'], w['m_edges'], w['pt_edges']
+
+rhTreeStr = args.infile 
+rhTree = ROOT.TChain("fevt/RHTree")
+rhTree.Add(rhTreeStr)
+nEvts = rhTree.GetEntries()
+assert nEvts > 0
+print " >> Input file:",rhTreeStr
+print " >> nEvts:",nEvts
+
+data = [
+        pa.array([np.zeros((1,32,32)).tolist()]),
+        pa.array([np.zeros((2,32,32)).tolist()]),
+        pa.array([124.]),
+        pa.array([60.]),
+        pa.array([360.]),
+        pa.array([85.])
+        ]
+#keys = ['X', 'm', 'pt']
+keys = ['X', 'Xtz', 'm', 'pt', 'iphi', 'ieta']
+table = pa.Table.from_arrays(data, keys)
+outStr = '%s/%s.parquet.%d'%(args.outdir, args.decay, args.idx) 
+#outStr = '%s.parquet.%d'%(args.decay, args.idx) 
+writer = pq.ParquetWriter(outStr, table.schema, compression='snappy')
+
+##### EVENT SELECTION START #####
+
+# Event range to process
+iEvtStart = 0
+iEvtEnd   = 100
+iEvtEnd   = nEvts 
+assert iEvtEnd <= nEvts
+print " >> Processing entries: [",iEvtStart,"->",iEvtEnd,")"
+
+nAcc = 0
+sw = ROOT.TStopwatch()
+sw.Start()
+for iEvt in range(iEvtStart,iEvtEnd):
+
+    # Initialize event
+    rhTree.GetEntry(iEvt)
+
+    if iEvt % 10000 == 0:
+        print " .. Processing entry",iEvt
+
+    SC_energyT = rhTree.SC_energyT
+    SC_energyZ = rhTree.SC_energyZ
+    SC_energy = rhTree.SC_energy
+    SC_mass = rhTree.SC_mass
+    SC_pT = rhTree.SC_pT
+    SC_iphi = rhTree.SC_iphi
+    SC_ieta = rhTree.SC_ieta
+    #EB_energy = rhTree.EB_energy
+    rands = np.random.random((len(SC_mass,)))
+
+    for i in range(len(SC_mass)):
+
+        sc_mass = SC_mass[i]
+        sc_pT = SC_pT[i]
+        sc_iphi = SC_iphi[i]
+        sc_ieta = SC_ieta[i]
+
+        if rands[i] < get_weight_2d(sc_mass, sc_pT, m_edges, pt_edges, hmvpt):
+            continue
+
+        sc_energy = np.array(SC_energy[i]).reshape(1,32,32).tolist()
+        sc_energyT = np.array(SC_energyT[i]).reshape(1,32,32)
+        sc_energyZ = np.array(SC_energyT[i]).reshape(1,32,32)
+        sc_energyTZ = np.concatenate((sc_energyT, sc_energyZ), axis=0).tolist()
+        #eb_energy = np.array(EB_energy).reshape(1,170,360).tolist()
+
+        pqdata = [
+                pa.array([sc_energy])
+                ,pa.array([sc_energyTZ])
+                ,pa.array([sc_mass])
+                ,pa.array([sc_pT])
+                ,pa.array([sc_iphi])
+                ,pa.array([sc_ieta])
+                #,pa.array([eb_energy]) 
+                ]
+
+        table = pa.Table.from_arrays(pqdata, keys)
+        writer.write_table(table)
+        nAcc += 1
+
+writer.close()
+
+sw.Stop()
+#print " >> nPhos:",nAcc,"/",2*(iEvtEnd-iEvtStart),"(",100.*nAcc/(2*(iEvtEnd-iEvtStart)),"% )"
+print " >> nPhos:",nAcc
+print " >> Real time:",sw.RealTime()/60.,"minutes"
+print " >> CPU time: ",sw.CpuTime() /60.,"minutes"
+
+pqIn = pq.ParquetFile(outStr)
+print(pqIn.metadata)
+print(pqIn.schema)
+#X = pqIn.read_row_group(0, columns=['X.list.item.list.item.list.item', 'm', 'pt'], nthreads=len(keys)).to_pydict()['X']
+#X = pqIn.read(['X.list.item.list.item.list.item']).to_pydict()['X']
+#X = np.float32(X)

--- a/get_mvpt_weights_dR.py
+++ b/get_mvpt_weights_dR.py
@@ -1,0 +1,175 @@
+import ROOT
+import numpy as np
+np.random.seed(0)
+import glob, os
+
+import argparse
+parser = argparse.ArgumentParser(description='Process some integers.')
+parser.add_argument('-d', '--genDR', default=10, type=int, help='gen-level dR.')
+parser.add_argument('-p', '--p_drop', default=0.95, type=float, help='p(drop) scale.')
+args = parser.parse_args()
+
+eosDir='/eos/uscms/store/user/lpcml/mandrews/IMG'
+#eosDir='/store/user/lpcml/mandrews/IMG'
+#outDir='~lpcml/nobackup/mandrews' # NOTE: Space here is limited, transfer files to EOS after processing
+xrootd='root://cmsxrootd.fnal.gov' # FNAL
+#xrootd='root://eoscms.cern.ch' # CERN
+
+genDR = args.genDR
+p_drop_scale = args.p_drop
+decay = 'DoublePi0Pt15To100_m0To1600_pythia8_noPU_mlog_ptexp'
+#decay = '%s_genDR%d_recoDR16_IMG'%(decay, genDR)
+decay = '%s_genDR%d_recoDR16_seedPos_IMG'%(decay, genDR)
+if genDR == 5:
+    date_str = '190219_012120' # DR5
+else:
+    #date_str = '190221_195631'
+    date_str = '190221_191131' # DR10
+    #date_str = '190219_012301' # DR10
+
+# Load input TTrees into TChain
+rhTreeStrs = '%s/%s/%s/*/output_*.root'%(eosDir, decay, date_str)
+print(" >> Input string: %s"%rhTreeStrs)
+rhTreeStrs = glob.glob(rhTreeStrs)
+assert len(rhTreeStrs) > 0 
+print(" >> %d files found"%len(rhTreeStrs))
+rhTreeStrs = [('%s/%s'%(xrootd, rhtree)).replace('/eos/uscms','') for rhtree in rhTreeStrs]
+print(' >> infile[0]: %s'%rhTreeStrs[0])
+
+rhTree = ROOT.TChain("fevt/RHTree")
+for t in rhTreeStrs:
+    rhTree.Add(t)
+nEvts = rhTree.GetEntries()
+assert nEvts > 0
+print " >> nEvts:",nEvts
+
+##### EVENT SELECTION START #####
+
+# Event range to process
+iEvtStart = 0
+iEvtEnd   = 10000
+iEvtEnd   = nEvts 
+assert iEvtEnd <= nEvts
+print " >> Processing entries: [",iEvtStart,"->",iEvtEnd,")"
+
+eb_xtal = 0.0174
+
+nAcc = 0
+sc_mass_, sc_pT_, sc_dR_ = [], [], []
+hnPho = ROOT.TH2F("hnPho", "hnPho;m_{#pi^{0}};p_{T,#pi^{0}}", 16, 0, 1.6 , 20, 20., 100.)
+
+sw = ROOT.TStopwatch()
+sw.Start()
+for iEvt in range(iEvtStart,iEvtEnd):
+
+    rhTree.GetEntry(iEvt)
+
+    if iEvt % 10000 == 0:
+        print " .. Processing entry",iEvt
+
+    SC_mass = rhTree.SC_mass
+    SC_pT = rhTree.SC_pT
+    SC_dR = rhTree.SC_DR
+
+    for i in range(len(SC_mass)):
+
+        sc_mass = SC_mass[i] 
+        sc_pT = SC_pT[i] 
+        sc_dR = SC_dR[i] 
+
+        hnPho.Fill(sc_mass, sc_pT) 
+        nAcc += 1
+
+        sc_mass_.append(sc_mass)
+        sc_pT_.append(sc_pT)
+        sc_dR_.append(sc_dR)
+
+sw.Stop()
+print " >> Real time:",sw.RealTime()/60.,"minutes"
+print " >> CPU time: ",sw.CpuTime() /60.,"minutes"
+print " >> nPi0s: ", nAcc
+
+sc_mass_ = np.array(sc_mass_)
+sc_pT_ = np.array(sc_pT_)
+sc_dR_ = np.array(sc_dR_)
+
+hmvpt, m_edges, pt_edges = np.histogram2d(sc_mass_, sc_pT_, range=((0., 1.6), (20.,100.)), bins=(16, 20))
+hmvpt = hmvpt/hmvpt.max()
+floor = np.mean(hmvpt.flatten()) - 2.*np.std(hmvpt.flatten())
+if floor < 0.:
+    print " >> Forcing floor to %f -> 0."%floor
+    floor = 0.
+print " >> w(m_v_pt) floor:",floor
+hmvpt[hmvpt < floor] = floor
+hmvpt = hmvpt/hmvpt.max()
+hmvpt = hmvpt-hmvpt.min()
+print " >> p(drop) scale:",p_drop_scale
+hmvpt = p_drop_scale*hmvpt
+print " >> w(m_v_pt)*p(drop) min, max:",hmvpt.min(), hmvpt.max()
+np.savez('%s_mvpt_weights_pdrop%.2f.npz'%(decay, p_drop_scale),\
+        mvpt = hmvpt,
+        m_edges = m_edges,
+        pt_edges = pt_edges,
+        sc_mass = sc_mass_,
+        sc_pT = sc_pT_,
+        sc_dR = sc_dR_
+        )
+
+#hnPho.Draw("COL Z")
+
+def get_weight_2d(m0, pt, m0_edges, pt_edges, wgts):
+    idx_m0 = np.argmax(m0 <= m0_edges)-1
+    idx_pt = np.argmax(pt <= pt_edges)-1
+    #print(idx_m0, idx_pt)
+    return wgts[idx_m0, idx_pt]
+
+hnPhow = ROOT.TH2F("hnPhow", "hnPhow;m_{#pi^{0}};p_{T,#pi^{0}}", 16, 0, 1.6 , 20, 20., 100.)
+nAcc = 0
+for iEvt in range(iEvtStart,iEvtEnd):
+
+    rhTree.GetEntry(iEvt)
+
+    if iEvt % 10000 == 0:
+        print " .. Processing entry",iEvt
+
+    SC_mass = rhTree.SC_mass
+    SC_pT = rhTree.SC_pT
+    #SC_dR = rhTree.SC_DR
+    rands = np.random.random((len(SC_mass,)))
+
+    for i in range(len(SC_mass)):
+
+        sc_mass = SC_mass[i] 
+        sc_pT = SC_pT[i] 
+        #sc_dR = SC_dR[i] 
+
+        if rands[i] < get_weight_2d(sc_mass, sc_pT, m_edges, pt_edges, hmvpt):
+            continue
+
+        hnPhow.Fill(sc_mass, sc_pT) 
+        nAcc += 1
+
+print " >> nPi0s: ", nAcc
+hnPhow.Draw("COL Z")
+
+hFile = ROOT.TFile("%s_hnPho_pdrop%.2f.root"%(decay, p_drop_scale),"RECREATE")
+
+hnPho.SetMinimum(0.)
+hnPho.Write()
+hnPhoX = hnPho.ProjectionX()
+hnPhoX.GetYaxis().SetRangeUser(0., 1.2*hnPhoX.GetMaximum())
+hnPhoX.Write()
+hnPhoY = hnPho.ProjectionY()
+hnPhoY.GetYaxis().SetRangeUser(0., 1.2*hnPhoY.GetMaximum())
+hnPhoY.Write()
+
+hnPhow.SetMinimum(0.)
+hnPhow.Write()
+hnPhowX = hnPhow.ProjectionX()
+hnPhowX.GetYaxis().SetRangeUser(0., 1.2*hnPhowX.GetMaximum())
+hnPhowX.Write()
+hnPhowY = hnPhow.ProjectionY()
+hnPhowY.GetYaxis().SetRangeUser(0., 1.2*hnPhowY.GetMaximum())
+hnPhowY.Write()
+
+hFile.Close()

--- a/runSCRegressor.py
+++ b/runSCRegressor.py
@@ -12,7 +12,10 @@ cfg='RecHitAnalyzer/python/SCRegressor_cfg.py'
 #inputFiles_='file:/eos/uscms/store/user/mba2012/AODSIM/SinglePi0Pt60_pythia8_2016_25ns_Moriond17MC_PoissonOOTPU_AODSIM_m600/180611_092217/0000/step_full_1.root'
 #inputFiles_='/store/user/lpcml/mandrews/AODSIM/DoublePi0Pt30To50_m0To1600_pythia8_2016_25ns_Moriond17MC_PoissonOOTPU_AODSIM/180917_151524/0000/step_full_1.root'
 #inputFiles_='/store/user/lpcml/mandrews/AODSIM/DoublePi0Pt15To100_m0To1600_pythia8_2016_25ns_Moriond17MC_PoissonOOTPU_AODSIM/181212_004828/0000/step_full_1.root'
-inputFiles_='/store/user/lpcml/mandrews/AODSIM/DoublePi0Pt15To100_m0To1600_pythia8_noPU_AODSIM/190116_160039/0000/step_full_1.root'
+#inputFiles_='/store/user/lpcml/mandrews/AODSIM/DoublePi0Pt15To100_m0To1600_pythia8_noPU_AODSIM/190116_160039/0000/step_full_1.root'
+#inputFiles_='/store/user/lpcml/mandrews/AODSIM/DoublePhotonPt15To100_pythia8_noPU_AODSIM/190219_231402/0000/step_full_1.root'
+#inputFiles_='/store/user/lpcml/mandrews/AODSIM/DoublePi0Pt15To100_m000_pythia8_noPU_AODSIM/190220_040632/0000/step_full_1.root'
+inputFiles_='/store/user/lpcml/mandrews/AODSIM/DoublePi0Pt15To100_m0To1600_pythia8_noPU_AODSIM_mlog_ptexp/190217_185619/0000/step_full_1.root'
 
 #inputFiles_='file:step_full_filtered.root'
 maxEvents_=-1

--- a/run_root2pq_EBshower_multiproc.py
+++ b/run_root2pq_EBshower_multiproc.py
@@ -1,0 +1,75 @@
+import os, glob, re
+from multiprocessing import Pool
+
+def alphanum_key(s):
+    """ Turn a string into a list of string and number chunks.
+        "z23a" -> ["z", 23, "a"]
+    """
+    return [int(c) if c.isdigit() else c for c in re.split('([0-9]+)',s)]
+
+def sort_nicely(l):
+    """ Sort the given list in the way that humans expect.
+    """
+    l.sort(key=alphanum_key)
+
+import argparse
+parser = argparse.ArgumentParser(description='Process some integers.')
+parser.add_argument('-d', '--genDR', default=10, type=int, help='gen-level dR.')
+parser.add_argument('-p', '--p_drop', default=0.95, type=float, help='p(drop) scale.')
+args = parser.parse_args()
+
+eosDir='/eos/uscms/store/user/lpcml/mandrews/IMG'
+#eosDir='/store/user/lpcml/mandrews/IMG'
+#outDir='~lpcml/nobackup/mandrews' # NOTE: Space here is limited, transfer files to EOS after processing
+xrootd='root://cmsxrootd.fnal.gov' # FNAL
+#xrootd='root://eoscms.cern.ch' # CERN
+
+genDR = args.genDR
+p_drop_scale = args.p_drop
+
+decay = 'DoublePi0Pt15To100_m0To1600_pythia8_noPU_mlog_ptexp'
+#decay = '%s_genDR%d_recoDR16_IMG'%(decay, genDR)
+decay = '%s_genDR%d_recoDR16_seedPos_IMG'%(decay, genDR)
+if genDR == 5:
+    date_str = '190219_012120' #DR5
+else:
+    #date_str = '190219_012301' #DR10
+    date_str = '190221_191131' #DR10
+#decay = 'DoublePi0Pt15To100_m0To1600_pythia8_2016_25ns_Moriond17MC_PoissonOOTPU_IMG'
+#date_str = '190214_155902'
+#decay = 'DoublePi0Pt15To100_m000_pythia8_noPU_genDR10_recoDR16_IMG'
+#date_str = '190220_160854'
+#decay = 'DoublePhotonPt15To100_pythia8_noPU_IMG'
+#date_str = '190220_155357'
+#decay = 'DoublePhotonPt15To100_pythia8_noPU_seedPos_IMG'
+#date_str = '190221_195631'
+
+# Load input TTrees into TChain
+rhTreeStrs = '%s/%s/%s/*/output_*.root'%(eosDir, decay, date_str)
+print(" >> Input string: %s"%rhTreeStrs)
+rhTreeStrs = glob.glob(rhTreeStrs)
+assert len(rhTreeStrs) > 0
+print(" >> %d files found"%len(rhTreeStrs))
+rhTreeStrs = [('%s/%s'%(xrootd, rhtree)).replace('/eos/uscms','') for rhtree in rhTreeStrs]
+print(' >> infile[0]: %s'%rhTreeStrs[0])
+sort_nicely(rhTreeStrs)
+
+wgt_file = '%s_mvpt_weights_pdrop%.2f.npz'%(decay, p_drop_scale)
+assert os.path.isfile(wgt_file) 
+
+outDir='/uscms/physics_grp/lpcml/nobackup/mandrews/%s'%(decay)
+if not os.path.isdir(outDir):
+    os.makedirs(outDir)
+print(' >> outdir: %s'%outDir)
+
+proc_file = 'convert_root2pq_EBshower.py'
+#proc_file = 'convert_root2pq_EBshower_lhood.py'
+processes = ['%s -i %s -o %s -d %s -n %d -w %s'%(proc_file, rhtree, outDir, decay, i+1, wgt_file) for i,rhtree in enumerate(rhTreeStrs)]
+#processes = ['%s -i %s -o %s -d %s -n %d'%(proc_file, rhtree, outDir, decay, i+1) for i,rhtree in enumerate(rhTreeStrs)]
+print(' >> process[0]: %s'%processes[0])
+
+def run_process(process):
+    os.system('python %s'%process)
+
+pool = Pool(processes=len(processes))
+pool.map(run_process, processes)


### PR DESCRIPTION
- Split SCRegressor into shower selection, seed finding, and image filling
- Allow for variable number of photons to be selected per event and keep mapping between gen-level pi0s and matched reco photons
- Write out seed coordinates (iphi, ieta) of selected photons
- Add scripts for converting from root to parquet, with variable number of photons per event and multi-processing per input file