### PR TITLE
Add root -> parquet scripts for jet ID

### DIFF
--- a/convert_root2pq_jet.py
+++ b/convert_root2pq_jet.py
@@ -1,0 +1,158 @@
+import pyarrow.parquet as pq
+import pyarrow as pa # pip install pyarrow==0.7.1
+import ROOT
+import numpy as np
+import glob, os
+from skimage.measure import block_reduce # pip install scikit-image
+from numpy.lib.stride_tricks import as_strided
+
+import argparse
+parser = argparse.ArgumentParser(description='Process some integers.')
+parser.add_argument('-i', '--infile', default='output.root', type=str, help='Input root file.')
+parser.add_argument('-o', '--outdir', default='.', type=str, help='Output pq file dir.')
+parser.add_argument('-d', '--decay', default='test', type=str, help='Decay name.')
+parser.add_argument('-n', '--idx', default=0, type=int, help='Input root file index.')
+args = parser.parse_args()
+
+def upsample_array(x, b0, b1):
+
+    r, c = x.shape                                    # number of rows/columns
+    rs, cs = x.strides                                # row/column strides
+    x = as_strided(x, (r, b0, c, b1), (rs, 0, cs, 0)) # view as a larger 4D array
+
+    return x.reshape(r*b0, c*b1)/(b0*b1)              # create new 2D array with same total occupancy 
+
+def resample_EE(imgECAL, factor=2):
+
+    # EE-
+    imgEEm = imgECAL[:140-85] # EE- in the first 55 rows
+    imgEEm = np.pad(imgEEm, ((1,0),(0,0)), 'constant', constant_values=0) # for even downsampling, zero pad 55 -> 56
+    imgEEm_dn = block_reduce(imgEEm, block_size=(factor, factor), func=np.sum) # downsample by summing over [factor, factor] window
+    imgEEm_dn_up = upsample_array(imgEEm_dn, factor, factor)/(factor*factor) # upsample will use same values so need to correct scale by factor**2
+    imgECAL[:140-85] = imgEEm_dn_up[1:] ## replace the old EE- rows
+
+    # EE+
+    imgEEp = imgECAL[140+85:] # EE+ in the last 55 rows
+    imgEEp = np.pad(imgEEp, ((0,1),(0,0)), 'constant', constant_values=0) # for even downsampling, zero pad 55 -> 56
+    imgEEp_dn = block_reduce(imgEEp, block_size=(factor, factor), func=np.sum) # downsample by summing over [factor, factor] window
+    imgEEp_dn_up = upsample_array(imgEEp_dn, factor, factor)/(factor*factor) # upsample will use same values so need to correct scale by factor*factor
+    imgECAL[140+85:] = imgEEp_dn_up[:-1] # replace the old EE+ rows
+
+    return imgECAL
+
+def crop_jet(imgECAL, iphi, ieta, jet_shape=125):
+
+    # NOTE: jet_shape here should correspond to the one used in RHAnalyzer
+    off = jet_shape//2
+    iphi = int(iphi*5 + 2) # 5 EB xtals per HB tower
+    ieta = int(ieta*5 + 2) # 5 EB xtals per HB tower
+
+    # Wrap-around on left side
+    if iphi < off:
+        diff = off-iphi
+        img_crop = np.concatenate((imgECAL[:,ieta-off:ieta+off+1,-diff:],
+                                   imgECAL[:,ieta-off:ieta+off+1,:iphi+off+1]), axis=-1)
+    # Wrap-around on right side
+    elif 360-iphi < off:
+        diff = off - (360-iphi)
+        img_crop = np.concatenate((imgECAL[:,ieta-off:ieta+off+1,iphi-off:],
+                                   imgECAL[:,ieta-off:ieta+off+1,:diff+1]), axis=-1)
+    # Nominal case
+    else:
+        img_crop = imgECAL[:,ieta-off:ieta+off+1,iphi-off:iphi+off+1]
+
+    return img_crop
+
+rhTreeStr = args.infile 
+rhTree = ROOT.TChain("fevt/RHTree")
+rhTree.Add(rhTreeStr)
+nEvts = rhTree.GetEntries()
+assert nEvts > 0
+print " >> Input file:",rhTreeStr
+print " >> nEvts:",nEvts
+
+# Define parquet file schema and keys
+data = [
+        pa.array([np.zeros((3,125,125)).tolist()])
+        ,pa.array([1.])
+        ,pa.array([100.])
+        ,pa.array([72.])
+        ,pa.array([17.])
+        ,pa.array([17.])
+        ]
+keys = ['X_jet', 'y', 'pt', 'iphi', 'ieta', 'pdgId']
+table = pa.Table.from_arrays(data, keys)
+outStr = '%s/%s.parquet.%d'%(args.outdir, args.decay, args.idx) 
+writer = pq.ParquetWriter(outStr, table.schema, compression='snappy')
+
+##### MAIN #####
+
+# Event range to process
+iEvtStart = 0
+#iEvtEnd   = 10
+iEvtEnd   = nEvts 
+assert iEvtEnd <= nEvts
+print " >> Processing entries: [",iEvtStart,"->",iEvtEnd,")"
+
+nAcc = 0
+sw = ROOT.TStopwatch()
+sw.Start()
+for iEvt in range(iEvtStart,iEvtEnd):
+
+    # Initialize event
+    rhTree.GetEntry(iEvt)
+
+    if iEvt % 10000 == 0:
+        print " .. Processing entry",iEvt
+
+    ECAL_energy = np.array(rhTree.ECAL_energy).reshape(280,360)
+    ECAL_energy = resample_EE(ECAL_energy)
+    HBHE_energy = np.array(rhTree.HBHE_energy).reshape(56,72)
+    HBHE_energy = upsample_array(HBHE_energy, 5, 5) # (280, 360)
+    TracksAtECAL_pt = np.array(rhTree.ECAL_tracksPt).reshape(280,360)
+    X_CMSII = np.stack([TracksAtECAL_pt, ECAL_energy, HBHE_energy], axis=0) # (3, 280, 360)
+
+    # Jet attributes 
+    ys = rhTree.jetIsQuark
+    pts = rhTree.jetPt
+    iphis = rhTree.jetSeed_iphi
+    ietas = rhTree.jetSeed_ieta
+    pdgIds = rhTree.jetPdgIds
+    njets = len(ys)
+
+    for i in range(njets):
+
+        y = ys[i]
+        pt = pts[i]
+        iphi = iphis[i]
+        ieta = ietas[i]
+        pdgId = pdgIds[i]
+        X_jet = crop_jet(X_CMSII, iphi, ieta) # (3, 125, 125)
+
+        # Create pyarrow.Table
+        pqdata = [
+                pa.array([X_jet.tolist()]) # arrays must be converted to lists
+                ,pa.array([y])
+                ,pa.array([pt])
+                ,pa.array([iphi])
+                ,pa.array([ieta])
+                ,pa.array([pdgId])
+                ]
+        table = pa.Table.from_arrays(pqdata, keys)
+        writer.write_table(table)
+
+        nAcc += 1
+
+writer.close()
+sw.Stop()
+print " >> nJets:",nAcc
+print " >> Real time:",sw.RealTime()/60.,"minutes"
+print " >> CPU time: ",sw.CpuTime() /60.,"minutes"
+print "========================================================"
+
+pqIn = pq.ParquetFile(outStr)
+print(pqIn.metadata)
+print(pqIn.schema)
+#X = pqIn.read_row_group(0, columns=['X_jet.list.item.list.item.list.item', 'y'], nthreads=len(keys)).to_pydict()['X_jet'] # read row-by-row 
+#X = pqIn.read(['X_jet.list.item.list.item.list.item', 'y']).to_pydict()['X_jet'] # read entire column(s)
+#X = np.float32(X)

--- a/run_root2pq_jet_multiproc.py
+++ b/run_root2pq_jet_multiproc.py
@@ -1,0 +1,46 @@
+import os, glob, re
+from multiprocessing import Pool
+
+def alphanum_key(s):
+    """ Turn a string into a list of string and number chunks.
+        "z23a" -> ["z", 23, "a"]
+    """
+    return [int(c) if c.isdigit() else c for c in re.split('([0-9]+)',s)]
+
+def sort_nicely(l):
+    """ Sort the given list in the way that humans expect.
+    """
+    l.sort(key=alphanum_key)
+
+def run_process(process):
+    os.system('python %s'%process)
+
+xrootd='root://cmsxrootd.fnal.gov' # FNAL
+#xrootd='root://eoscms.cern.ch' # CERN
+eosDir='/eos/uscms/store/user/lpcml/mandrews/IMG'
+
+decay = 'QCDToGG_Pt_80_120_13TeV_TuneCUETP8M1_noPU_IMG'
+
+# Paths to input files
+rhFileList = '%s/%s/*/*/output_*.root'%(eosDir, decay)
+print(" >> Input file list: %s"%rhFileList)
+rhFileList = glob.glob(rhFileList)
+assert len(rhFileList) > 0
+print(" >> %d files found"%len(rhFileList))
+rhFileList = [('%s/%s'%(xrootd, rhFile)).replace('/eos/uscms','') for rhFile in rhFileList]
+print(' >> Input File[0]: %s'%rhFileList[0])
+sort_nicely(rhFileList)
+
+# Output path
+outDir='/uscms/physics_grp/lpcml/nobackup/mandrews' # NOTE: Space here is limited, transfer files to EOS after processing
+outDir='%s/%s'%(outDir, decay)
+if not os.path.isdir(outDir):
+    os.makedirs(outDir)
+print(' >> Output directory: %s'%outDir)
+
+proc_file = 'convert_root2pq_jet.py'
+processes = ['%s -i %s -o %s -d %s -n %d'%(proc_file, rhtree, outDir, decay, i+1) for i,rhtree in enumerate(rhFileList)]
+print(' >> Process[0]: %s'%processes[0])
+
+pool = Pool(processes=len(processes))
+pool.map(run_process, processes)


### PR DESCRIPTION
- Add basic jet ID conversion script for converting RHAnalyzer root trees to parquet format files.
- Add script to run jet ID conversion script in multiprocessing mode (for multiple input files).

NOTE: conversion script requires pyarrow to be installed (e.g. `pip install pyarrow==0.7.1` inside cmslpc/lxplus virtualenv)