### PR TITLE
Adding b tagging val

### DIFF
--- a/RecHitAnalyzer/interface/RecHitAnalyzer.h
+++ b/RecHitAnalyzer/interface/RecHitAnalyzer.h
@@ -75,6 +75,7 @@
 #include "DataFormats/JetReco/interface/GenJetCollection.h"
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
+#include "DataFormats/BTauReco/interface/JetTag.h"
 
 //
 // class declaration
@@ -111,7 +112,9 @@ class RecHitAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
     edm::EDGetTokenT<reco::PFJetCollection> jetCollectionT_;
     edm::EDGetTokenT<reco::GenJetCollection> genJetCollectionT_;
     edm::EDGetTokenT<reco::TrackCollection> trackCollectionT_;
-
+    edm::EDGetTokenT<edm::View<reco::Jet> > recoJetsT_;
+    edm::EDGetTokenT<reco::JetTagCollection> jetTagCollectionT_;
+    
     typedef std::vector<reco::PFCandidate>  PFCollection;
     edm::EDGetTokenT<PFCollection> pfCollectionT_;
     //edm::InputTag trackTags_; //used to select what tracks to read from configuration file
@@ -166,7 +169,8 @@ class RecHitAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
 
     const reco::PFCandidate* getPFCand(edm::Handle<PFCollection> pfCands, float eta, float phi, float& minDr, bool debug = false);
     const reco::Track* getTrackCand(edm::Handle<reco::TrackCollection> trackCands, float eta, float phi, float& minDr, bool debug = false);
-    int getTruthLabel(const reco::PFJetRef& recJet, edm::Handle<reco::GenParticleCollection> genParticles, float dRMatch = 0.4, bool debug = false);
+    int   getTruthLabel(const reco::PFJetRef& recJet, edm::Handle<reco::GenParticleCollection> genParticles, float dRMatch = 0.4, bool debug = false);
+    float getBTaggingValue(const reco::PFJetRef& recJet, edm::Handle<edm::View<reco::Jet> >& recoJetCollection, edm::Handle<reco::JetTagCollection>& btagCollection, float dRMatch = 0.1, bool debug= false );
 
     // Jet level functions
     std::string mode_;  // EventLevel / JetLevel

--- a/RecHitAnalyzer/plugins/RHAnalyzer_fillTracksAtEBEE.cc
+++ b/RecHitAnalyzer/plugins/RHAnalyzer_fillTracksAtEBEE.cc
@@ -10,17 +10,37 @@ TH2F *hTracksPt_EB;
 std::vector<float> vTracksPt_EE_[nEE];
 std::vector<float> vTracksQPt_EE_[nEE];
 std::vector<float> vTracks_EE_[nEE];
+std::vector<float> vTracksd0_EE_[nEE];
+std::vector<float> vTracksd0Sig_EE_[nEE];
+std::vector<float> vTracksz0_EE_[nEE];
+std::vector<float> vTracksz0Sig_EE_[nEE];
+std::vector<float> vTracksd0Signed_EE_[nEE];
+std::vector<float> vTracksd0SigSigned_EE_[nEE];
+std::vector<float> vTracksz0Signed_EE_[nEE];
+std::vector<float> vTracksz0SigSigned_EE_[nEE];
+
 std::vector<float> vTracksPt_EB_;
 std::vector<float> vTracksQPt_EB_;
 std::vector<float> vTracks_EB_;
+std::vector<float> vTracksd0_EB_;
+std::vector<float> vTracksd0Sig_EB_;
+std::vector<float> vTracksz0_EB_;
+std::vector<float> vTracksz0Sig_EB_;
+std::vector<float> vTracksd0Signed_EB_;
+std::vector<float> vTracksd0SigSigned_EB_;
+std::vector<float> vTracksz0Signed_EB_;
+std::vector<float> vTracksz0SigSigned_EB_;
+
 
 // Initialize branches ____________________________________________________________//
 void RecHitAnalyzer::branchesTracksAtEBEE ( TTree* tree, edm::Service<TFileService> &fs ) {
 
   // Branches for images
-  tree->Branch("Tracks_EB",   &vTracks_EB_);
-  tree->Branch("TracksPt_EB", &vTracksPt_EB_);
+  tree->Branch("Tracks_EB",    &vTracks_EB_);
+  tree->Branch("TracksPt_EB",  &vTracksPt_EB_);
   tree->Branch("TracksQPt_EB", &vTracksQPt_EB_);
+  tree->Branch("Tracksd0_EB",  &vTracksd0_EB_);
+  tree->Branch("Tracksd0_EB",  &vTracksd0_EB_);
 
   // Histograms for monitoring
   hTracks_EB = fs->make<TH2F>("Tracks_EB", "N(i#phi,i#eta);i#phi;i#eta",

--- a/RecHitAnalyzer/plugins/RHAnalyzer_fillTracksAtEBEE.cc
+++ b/RecHitAnalyzer/plugins/RHAnalyzer_fillTracksAtEBEE.cc
@@ -1,3 +1,4 @@
+
 #include "MLAnalyzer/RecHitAnalyzer/interface/RecHitAnalyzer.h"
 
 // Fill Tracks in EB+EE ////////////////////////////////
@@ -39,8 +40,18 @@ void RecHitAnalyzer::branchesTracksAtEBEE ( TTree* tree, edm::Service<TFileServi
   tree->Branch("Tracks_EB",    &vTracks_EB_);
   tree->Branch("TracksPt_EB",  &vTracksPt_EB_);
   tree->Branch("TracksQPt_EB", &vTracksQPt_EB_);
-  tree->Branch("Tracksd0_EB",  &vTracksd0_EB_);
-  tree->Branch("Tracksd0_EB",  &vTracksd0_EB_);
+
+  tree->Branch("Tracksd0_EB",     &vTracksd0_EB_);
+  tree->Branch("Tracksd0Sig_EB",  &vTracksd0Sig_EB_);
+  tree->Branch("Tracksz0_EB",     &vTracksz0_EB_);
+  tree->Branch("Tracksz0Sig_EB",  &vTracksz0Sig_EB_);
+
+  tree->Branch("Tracksd0Signed_EB",     &vTracksd0Signed_EB_);
+  tree->Branch("Tracksd0SigSigned_EB",  &vTracksd0SigSigned_EB_);
+  tree->Branch("Tracksz0Signed_EB",     &vTracksz0Signed_EB_);
+  tree->Branch("Tracksz0SigSigned_EB",  &vTracksz0SigSigned_EB_);
+
+
 
   // Histograms for monitoring
   hTracks_EB = fs->make<TH2F>("Tracks_EB", "N(i#phi,i#eta);i#phi;i#eta",
@@ -61,6 +72,25 @@ void RecHitAnalyzer::branchesTracksAtEBEE ( TTree* tree, edm::Service<TFileServi
     tree->Branch(hname,        &vTracksPt_EE_[iz]);
     sprintf(hname, "TracksQPt_EE%s",zside);
     tree->Branch(hname,        &vTracksQPt_EE_[iz]);
+
+    sprintf(hname, "Tracksd0_EE%s",zside);
+    tree->Branch(hname,        &vTracksd0_EE_[iz]);
+    sprintf(hname, "Tracksd0Sig_EE%s",zside);
+    tree->Branch(hname,        &vTracksd0Sig_EE_[iz]);
+    sprintf(hname, "Tracksz0_EE%s",zside);
+    tree->Branch(hname,        &vTracksz0_EE_[iz]);
+    sprintf(hname, "Tracksz0Sig_EE%s",zside);
+    tree->Branch(hname,        &vTracksz0Sig_EE_[iz]);
+
+    sprintf(hname, "Tracksd0Signed_EE%s",zside);
+    tree->Branch(hname,        &vTracksd0Signed_EE_[iz]);
+    sprintf(hname, "Tracksd0SigSigned_EE%s",zside);
+    tree->Branch(hname,        &vTracksd0SigSigned_EE_[iz]);
+    sprintf(hname, "Tracksz0Signed_EE%s",zside);
+    tree->Branch(hname,        &vTracksz0Signed_EE_[iz]);
+    sprintf(hname, "Tracksz0SigSigned_EE%s",zside);
+    tree->Branch(hname,        &vTracksz0SigSigned_EE_[iz]);
+
 
     // Histograms for monitoring
     sprintf(hname, "Tracks_EE%s",zside);
@@ -88,10 +118,30 @@ void RecHitAnalyzer::fillTracksAtEBEE ( const edm::Event& iEvent, const edm::Eve
   vTracks_EB_.assign( EBDetId::kSizeForDenseIndexing, 0. );
   vTracksPt_EB_.assign( EBDetId::kSizeForDenseIndexing, 0. );
   vTracksQPt_EB_.assign( EBDetId::kSizeForDenseIndexing, 0. );
+  vTracksd0_EB_.assign( EBDetId::kSizeForDenseIndexing, 0. );
+  vTracksd0Sig_EB_.assign( EBDetId::kSizeForDenseIndexing, 0. );
+  vTracksz0_EB_.assign( EBDetId::kSizeForDenseIndexing, 0. );
+  vTracksz0Sig_EB_.assign( EBDetId::kSizeForDenseIndexing, 0. );
+  vTracksd0Signed_EB_.assign( EBDetId::kSizeForDenseIndexing, 0. );
+  vTracksd0SigSigned_EB_.assign( EBDetId::kSizeForDenseIndexing, 0. );
+  vTracksz0Signed_EB_.assign( EBDetId::kSizeForDenseIndexing, 0. );
+  vTracksz0SigSigned_EB_.assign( EBDetId::kSizeForDenseIndexing, 0. );
+
   for ( int iz(0); iz < nEE; iz++ ) {
     vTracks_EE_[iz].assign( EE_NC_PER_ZSIDE, 0. );
     vTracksPt_EE_[iz].assign( EE_NC_PER_ZSIDE, 0. );
     vTracksQPt_EE_[iz].assign( EE_NC_PER_ZSIDE, 0. );
+
+    vTracksd0_EE_[iz].assign( EE_NC_PER_ZSIDE, 0. );
+    vTracksd0Sig_EE_[iz].assign( EE_NC_PER_ZSIDE, 0. );
+    vTracksz0_EE_[iz].assign( EE_NC_PER_ZSIDE, 0. );
+    vTracksz0Sig_EE_[iz].assign( EE_NC_PER_ZSIDE, 0. );
+
+    vTracksd0Signed_EE_[iz].assign( EE_NC_PER_ZSIDE, 0. );
+    vTracksd0SigSigned_EE_[iz].assign( EE_NC_PER_ZSIDE, 0. );
+    vTracksz0Signed_EE_[iz].assign( EE_NC_PER_ZSIDE, 0. );
+    vTracksz0SigSigned_EE_[iz].assign( EE_NC_PER_ZSIDE, 0. );
+
   }
 
   edm::Handle<reco::TrackCollection> tracksH_;

--- a/RecHitAnalyzer/plugins/RHAnalyzer_fillTracksAtEBEE.cc
+++ b/RecHitAnalyzer/plugins/RHAnalyzer_fillTracksAtEBEE.cc
@@ -11,26 +11,10 @@ TH2F *hTracksPt_EB;
 std::vector<float> vTracksPt_EE_[nEE];
 std::vector<float> vTracksQPt_EE_[nEE];
 std::vector<float> vTracks_EE_[nEE];
-std::vector<float> vTracksd0_EE_[nEE];
-std::vector<float> vTracksd0Sig_EE_[nEE];
-std::vector<float> vTracksz0_EE_[nEE];
-std::vector<float> vTracksz0Sig_EE_[nEE];
-std::vector<float> vTracksd0Signed_EE_[nEE];
-std::vector<float> vTracksd0SigSigned_EE_[nEE];
-std::vector<float> vTracksz0Signed_EE_[nEE];
-std::vector<float> vTracksz0SigSigned_EE_[nEE];
 
 std::vector<float> vTracksPt_EB_;
 std::vector<float> vTracksQPt_EB_;
 std::vector<float> vTracks_EB_;
-std::vector<float> vTracksd0_EB_;
-std::vector<float> vTracksd0Sig_EB_;
-std::vector<float> vTracksz0_EB_;
-std::vector<float> vTracksz0Sig_EB_;
-std::vector<float> vTracksd0Signed_EB_;
-std::vector<float> vTracksd0SigSigned_EB_;
-std::vector<float> vTracksz0Signed_EB_;
-std::vector<float> vTracksz0SigSigned_EB_;
 
 
 // Initialize branches ____________________________________________________________//
@@ -40,17 +24,6 @@ void RecHitAnalyzer::branchesTracksAtEBEE ( TTree* tree, edm::Service<TFileServi
   tree->Branch("Tracks_EB",    &vTracks_EB_);
   tree->Branch("TracksPt_EB",  &vTracksPt_EB_);
   tree->Branch("TracksQPt_EB", &vTracksQPt_EB_);
-
-  tree->Branch("Tracksd0_EB",     &vTracksd0_EB_);
-  tree->Branch("Tracksd0Sig_EB",  &vTracksd0Sig_EB_);
-  tree->Branch("Tracksz0_EB",     &vTracksz0_EB_);
-  tree->Branch("Tracksz0Sig_EB",  &vTracksz0Sig_EB_);
-
-  tree->Branch("Tracksd0Signed_EB",     &vTracksd0Signed_EB_);
-  tree->Branch("Tracksd0SigSigned_EB",  &vTracksd0SigSigned_EB_);
-  tree->Branch("Tracksz0Signed_EB",     &vTracksz0Signed_EB_);
-  tree->Branch("Tracksz0SigSigned_EB",  &vTracksz0SigSigned_EB_);
-
 
 
   // Histograms for monitoring
@@ -72,25 +45,6 @@ void RecHitAnalyzer::branchesTracksAtEBEE ( TTree* tree, edm::Service<TFileServi
     tree->Branch(hname,        &vTracksPt_EE_[iz]);
     sprintf(hname, "TracksQPt_EE%s",zside);
     tree->Branch(hname,        &vTracksQPt_EE_[iz]);
-
-    sprintf(hname, "Tracksd0_EE%s",zside);
-    tree->Branch(hname,        &vTracksd0_EE_[iz]);
-    sprintf(hname, "Tracksd0Sig_EE%s",zside);
-    tree->Branch(hname,        &vTracksd0Sig_EE_[iz]);
-    sprintf(hname, "Tracksz0_EE%s",zside);
-    tree->Branch(hname,        &vTracksz0_EE_[iz]);
-    sprintf(hname, "Tracksz0Sig_EE%s",zside);
-    tree->Branch(hname,        &vTracksz0Sig_EE_[iz]);
-
-    sprintf(hname, "Tracksd0Signed_EE%s",zside);
-    tree->Branch(hname,        &vTracksd0Signed_EE_[iz]);
-    sprintf(hname, "Tracksd0SigSigned_EE%s",zside);
-    tree->Branch(hname,        &vTracksd0SigSigned_EE_[iz]);
-    sprintf(hname, "Tracksz0Signed_EE%s",zside);
-    tree->Branch(hname,        &vTracksz0Signed_EE_[iz]);
-    sprintf(hname, "Tracksz0SigSigned_EE%s",zside);
-    tree->Branch(hname,        &vTracksz0SigSigned_EE_[iz]);
-
 
     // Histograms for monitoring
     sprintf(hname, "Tracks_EE%s",zside);

--- a/RecHitAnalyzer/plugins/RHAnalyzer_fillTracksAtEBEE.cc
+++ b/RecHitAnalyzer/plugins/RHAnalyzer_fillTracksAtEBEE.cc
@@ -72,30 +72,11 @@ void RecHitAnalyzer::fillTracksAtEBEE ( const edm::Event& iEvent, const edm::Eve
   vTracks_EB_.assign( EBDetId::kSizeForDenseIndexing, 0. );
   vTracksPt_EB_.assign( EBDetId::kSizeForDenseIndexing, 0. );
   vTracksQPt_EB_.assign( EBDetId::kSizeForDenseIndexing, 0. );
-  vTracksd0_EB_.assign( EBDetId::kSizeForDenseIndexing, 0. );
-  vTracksd0Sig_EB_.assign( EBDetId::kSizeForDenseIndexing, 0. );
-  vTracksz0_EB_.assign( EBDetId::kSizeForDenseIndexing, 0. );
-  vTracksz0Sig_EB_.assign( EBDetId::kSizeForDenseIndexing, 0. );
-  vTracksd0Signed_EB_.assign( EBDetId::kSizeForDenseIndexing, 0. );
-  vTracksd0SigSigned_EB_.assign( EBDetId::kSizeForDenseIndexing, 0. );
-  vTracksz0Signed_EB_.assign( EBDetId::kSizeForDenseIndexing, 0. );
-  vTracksz0SigSigned_EB_.assign( EBDetId::kSizeForDenseIndexing, 0. );
 
   for ( int iz(0); iz < nEE; iz++ ) {
     vTracks_EE_[iz].assign( EE_NC_PER_ZSIDE, 0. );
     vTracksPt_EE_[iz].assign( EE_NC_PER_ZSIDE, 0. );
     vTracksQPt_EE_[iz].assign( EE_NC_PER_ZSIDE, 0. );
-
-    vTracksd0_EE_[iz].assign( EE_NC_PER_ZSIDE, 0. );
-    vTracksd0Sig_EE_[iz].assign( EE_NC_PER_ZSIDE, 0. );
-    vTracksz0_EE_[iz].assign( EE_NC_PER_ZSIDE, 0. );
-    vTracksz0Sig_EE_[iz].assign( EE_NC_PER_ZSIDE, 0. );
-
-    vTracksd0Signed_EE_[iz].assign( EE_NC_PER_ZSIDE, 0. );
-    vTracksd0SigSigned_EE_[iz].assign( EE_NC_PER_ZSIDE, 0. );
-    vTracksz0Signed_EE_[iz].assign( EE_NC_PER_ZSIDE, 0. );
-    vTracksz0SigSigned_EE_[iz].assign( EE_NC_PER_ZSIDE, 0. );
-
   }
 
   edm::Handle<reco::TrackCollection> tracksH_;

--- a/RecHitAnalyzer/plugins/RHAnalyzer_runEvtSel_jet_dijet.cc
+++ b/RecHitAnalyzer/plugins/RHAnalyzer_runEvtSel_jet_dijet.cc
@@ -1,6 +1,9 @@
 #include "MLAnalyzer/RecHitAnalyzer/interface/RecHitAnalyzer.h"
+#include "DataFormats/BTauReco/interface/JetTag.h"
 
 using std::vector;
+using std::cout;
+using std::endl;
 
 TH1D *h_dijet_jet_pT;
 TH1D *h_dijet_jet_E;
@@ -12,6 +15,7 @@ vector<float> vDijet_jet_m0_;
 vector<float> vDijet_jet_eta_;
 vector<float> vDijet_jet_phi_;
 vector<float> vDijet_jet_truthLabel_;
+vector<float> vDijet_jet_btaggingValue_;
 
 
 // Initialize branches _____________________________________________________//
@@ -28,6 +32,7 @@ void RecHitAnalyzer::branchesEvtSel_jet_dijet( TTree* tree, edm::Service<TFileSe
   tree->Branch("jetEta",         &vDijet_jet_eta_);
   tree->Branch("jetPhi",         &vDijet_jet_phi_);
   tree->Branch("jet_truthLabel", &vDijet_jet_truthLabel_);
+  tree->Branch("jet_btagValue",  &vDijet_jet_btaggingValue_);
 
 } // branchesEvtSel_jet_dijet()
 
@@ -44,6 +49,7 @@ bool RecHitAnalyzer::runEvtSel_jet_dijet( const edm::Event& iEvent, const edm::E
   vDijet_jet_eta_.clear();
   vDijet_jet_phi_.clear();
   vDijet_jet_truthLabel_.clear();
+  vDijet_jet_btaggingValue_.clear();
 
   int nJet = 0;
   // Loop over jets
@@ -91,6 +97,14 @@ void RecHitAnalyzer::fillEvtSel_jet_dijet( const edm::Event& iEvent, const edm::
   edm::Handle<reco::GenParticleCollection> genParticles;
   iEvent.getByToken( genParticleCollectionT_, genParticles );
 
+  edm::Handle<edm::View<reco::Jet> > recoJetCollection;
+  iEvent.getByToken(recoJetsT_, recoJetCollection);
+
+  edm::Handle<reco::JetTagCollection> btagDiscriminators;
+  iEvent.getByToken(jetTagCollectionT_, btagDiscriminators);
+
+
+
   h_dijet_jet_nJet->Fill( vJetIdxs.size() );
   // Fill branches and histograms 
   for(int thisJetIdx : vJetIdxs){
@@ -127,7 +141,9 @@ void RecHitAnalyzer::fillEvtSel_jet_dijet( const edm::Event& iEvent, const edm::
     }
     vDijet_jet_truthLabel_      .push_back(truthLabel);
 
-
+    float bTagValue = getBTaggingValue(thisJet,recoJetCollection,btagDiscriminators);
+    vDijet_jet_btaggingValue_      .push_back(bTagValue);
   }
+
 
 } // fillEvtSel_jet_dijet()

--- a/RecHitAnalyzer/plugins/RecHitAnalyzer.cc
+++ b/RecHitAnalyzer/plugins/RecHitAnalyzer.cc
@@ -32,6 +32,10 @@ RecHitAnalyzer::RecHitAnalyzer(const edm::ParameterSet& iConfig)
   trackCollectionT_       = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("trackCollection"));
   pfCollectionT_          = consumes<PFCollection>(iConfig.getParameter<edm::InputTag>("pfCollection"));
 
+  recoJetsT_              = consumes<edm::View<reco::Jet> >(iConfig.getParameter<edm::InputTag>("recoJetsForBTagging"));
+  jetTagCollectionT_      = consumes<reco::JetTagCollection>(iConfig.getParameter<edm::InputTag>("jetTagCollection"));
+
+
   //johnda add configuration
   mode_      = iConfig.getParameter<std::string>("mode");
   minJetPt_  = iConfig.getParameter<double>("minJetPt");
@@ -269,6 +273,43 @@ int RecHitAnalyzer::getTruthLabel(const reco::PFJetRef& recJet, edm::Handle<reco
 
 
 
+
+  return -99;
+}
+
+
+float RecHitAnalyzer::getBTaggingValue(const reco::PFJetRef& recJet, edm::Handle<edm::View<reco::Jet> >& recoJetCollection, edm::Handle<reco::JetTagCollection>& btagCollection, float dRMatch, bool debug ){
+
+  // loop over jets
+  for( edm::View<reco::Jet>::const_iterator jetToMatch = recoJetCollection->begin(); jetToMatch != recoJetCollection->end(); ++jetToMatch )
+    {
+      reco::Jet thisJet = *jetToMatch;
+      float dR = reco::deltaR( recJet->eta(),recJet->phi(), thisJet.eta(),thisJet.phi() );
+      if(dR > 0.1) continue;
+
+      size_t idx = (jetToMatch - recoJetCollection->begin());
+      edm::RefToBase<reco::Jet> jetRef = recoJetCollection->refAt(idx);
+
+      std::cout << "btag discriminator value = " << (*btagCollection)[jetRef] << std::endl;
+      return (*btagCollection)[jetRef];
+  
+    }
+
+  if(debug){
+    std::cout << "ERROR  No btag match: " << std::endl;
+    
+    // loop over jets
+    for( edm::View<reco::Jet>::const_iterator jetToMatch = recoJetCollection->begin(); jetToMatch != recoJetCollection->end(); ++jetToMatch )
+      {
+	const reco::Jet thisJet = *jetToMatch;
+	std::cout << "\t Match attempt pt: " <<  thisJet.pt() << " vs " <<  recJet->pt()
+		  << " eta: " << thisJet.eta() << " vs " << recJet->eta()
+		  << "phi: "<< thisJet.phi() << " vs " << recJet->phi()
+		  << std::endl;
+	float dR = reco::deltaR( recJet->eta(),recJet->phi(), thisJet.eta(),thisJet.phi() );
+	std::cout << "dR " << dR << std::endl;
+      }
+  }    
 
   return -99;
 }

--- a/RecHitAnalyzer/plugins/RecHitAnalyzer.cc
+++ b/RecHitAnalyzer/plugins/RecHitAnalyzer.cc
@@ -232,7 +232,6 @@ int RecHitAnalyzer::getTruthLabel(const reco::PFJetRef& recJet, edm::Handle<reco
     std::cout << " Mathcing reco jetPt:" << recJet->pt() << " jetEta:" << recJet->eta() << " jetPhi:" << recJet->phi() << std::endl;
   }
 
-
   for (reco::GenParticleCollection::const_iterator iGen = genParticles->begin();
        iGen != genParticles->end();
        ++iGen) {
@@ -250,9 +249,6 @@ int RecHitAnalyzer::getTruthLabel(const reco::PFJetRef& recJet, edm::Handle<reco
     // 81 - 89 primary hadrons produced by hadronization process
     // 91 - 99 particles produced in decay process, or by Bose-Einstein effects
 
-    //if ( iGen->numberOfMothers() != 2 ) continue;
-    //if ( iGen->status() != 3 ) continue;
-
     // Do not want to match to the final particles in the shower
     if ( iGen->status() > 99 ) continue;
     
@@ -260,12 +256,18 @@ int RecHitAnalyzer::getTruthLabel(const reco::PFJetRef& recJet, edm::Handle<reco
     if ( iGen->pdgId() > 25 ) continue;
 
     float dR = reco::deltaR( recJet->eta(),recJet->phi(), iGen->eta(),iGen->phi() );
+
     if ( debug ) std::cout << " \t >> dR " << dR << " id:" << iGen->pdgId() << " status:" << iGen->status() << " nDaught:" << iGen->numberOfDaughters() << " pt:"<< iGen->pt() << " eta:" <<iGen->eta() << " phi:" <<iGen->phi() << " nMoms:" <<iGen->numberOfMothers()<< std::endl;
+
     if ( dR > dRMatch ) continue; 
     if ( debug ) std::cout << " Matched pdgID " << iGen->pdgId() << std::endl;
+
     return iGen->pdgId();
 
   } // gen particles 
+
+
+
 
 
   return -99;

--- a/RecHitAnalyzer/python/RHAnalyzer_cfi.py
+++ b/RecHitAnalyzer/python/RHAnalyzer_cfi.py
@@ -1,4 +1,5 @@
 
+
 import FWCore.ParameterSet.Config as cms 
 
 fevt = cms.EDAnalyzer('RecHitAnalyzer'
@@ -17,6 +18,9 @@ fevt = cms.EDAnalyzer('RecHitAnalyzer'
     , trackRecHitCollection = cms.InputTag('generalTracks')
     , trackCollection = cms.InputTag("generalTracks")
     , pfCollection = cms.InputTag("particleFlow")
+    , recoJetsForBTagging = cms.InputTag("ak4PFJetsCHS")
+    , jetTagCollection    = cms.InputTag("pfCombinedInclusiveSecondaryVertexV2BJetTags")
+                      
     , mode = cms.string("JetLevel")
 
     # Jet level cfg

--- a/runRHAnalyzer.py
+++ b/runRHAnalyzer.py
@@ -9,11 +9,12 @@ cfg='RecHitAnalyzer/python/ConfFile_cfg.py'
 
 #inputFiles_ ='/store/user/johnda/AODSIM/NonB_Pt_30_70_13TeV_TuneCUETP8M1_noPU_AODSIM/181020_000214/0000/step_AODSIM_9.root'
 inputFiles_ ='/store/user/johnda/AODSIM/QCD_Pt_30_70_13TeV_TuneCUETP8M1_noPU_AODSIM/181019_231226/0000/step_AODSIM_1.root'
+#inputFiles_ ='file:/uscms/home/jda102/nobackup/BTaggingML/CMSSW_8_0_30/src/step_AODSIM.root'
 #inputFiles_ = 'file:/eos/uscms/store/user/jda102/AODSIM/QCD_Pt_30_70_13TeV_TuneCUETP8M1_noPU_AODSIM/181019_231226/0000/step_AODSIM_83.root'
 
 #inputFiles_='/store/group/lpcml/mandrews/AODSIM/QCDToGG_Pt_80_120_13TeV_TuneCUETP8M1_noPU_AODSIM/180809_215549/0000/step_full_1.root'
 #inputFiles_='/store/group/lpcml/AODSIM/h24gamma_1j_1M_200MeV_2016_25ns_Moriond17MC_PoissonOOTPU_AODSIM/180907_083212/0000/step_full_1.root'
-#inputFiles_='file:../step_full.root'
+#inputFiles_='file:../step_AODSIM.root'
 
 maxEvents_=-1
 skipEvents_=0#

--- a/runRHAnalyzer.py
+++ b/runRHAnalyzer.py
@@ -7,8 +7,8 @@ cfg='RecHitAnalyzer/python/ConfFile_cfg.py'
 #inputFiles_='/store/user/johnda/AODSIM/Py8PtGun_bb_noPU_AODSIM/180731_210318/0000/step_AODSIM_1.root'
 #inputFiles_='/store/user/johnda/AODSIM/Py8PtGun_bb_noPU_AODSIM/180731_210318/0000/step_AODSIM_2.root'
 
-inputFiles_ ='/store/user/johnda/AODSIM/NonB_Pt_30_70_13TeV_TuneCUETP8M1_noPU_AODSIM/181020_000214/0000/step_AODSIM_9.root'
-#inputFiles_ ='/store/user/johnda/AODSIM/QCD_Pt_30_70_13TeV_TuneCUETP8M1_noPU_AODSIM/181019_231226/0000/step_AODSIM_1.root'
+#inputFiles_ ='/store/user/johnda/AODSIM/NonB_Pt_30_70_13TeV_TuneCUETP8M1_noPU_AODSIM/181020_000214/0000/step_AODSIM_9.root'
+inputFiles_ ='/store/user/johnda/AODSIM/QCD_Pt_30_70_13TeV_TuneCUETP8M1_noPU_AODSIM/181019_231226/0000/step_AODSIM_1.root'
 #inputFiles_ = 'file:/eos/uscms/store/user/jda102/AODSIM/QCD_Pt_30_70_13TeV_TuneCUETP8M1_noPU_AODSIM/181019_231226/0000/step_AODSIM_83.root'
 
 #inputFiles_='/store/group/lpcml/mandrews/AODSIM/QCDToGG_Pt_80_120_13TeV_TuneCUETP8M1_noPU_AODSIM/180809_215549/0000/step_full_1.root'


### PR DESCRIPTION
**Add b-tagging variables to RecHitAnalyzer:**
- Requires use of `ak4PFJetsCHS` jet collection and `pfCombinedInclusiveSecondaryVertexV2BJetTags` tag info for actual b-tag variables/discriminants 
- NOTE: tag info needs to be explicitly kept at AOD-level since it is dropped by default:
`'keep *_*TagInfo*_*_*'`
