### PR TITLE
Use pat::Photon classes. Loop over all reco photons in photon veto. Centralize filling of photon vars.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 *.txt
 *.pyc
 *.hdf5
+*.parquet*
 .*.*
 __init__.py

--- a/RecHitAnalyzer/interface/SCRegressor.h
+++ b/RecHitAnalyzer/interface/SCRegressor.h
@@ -30,6 +30,7 @@
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h" // reco::PhotonCollection defined here
+#include "DataFormats/PatCandidates/interface/Photon.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -56,6 +57,10 @@
 //
 // class declaration
 //
+using pat::PhotonCollection;
+using pat::PhotonRef;
+//using reco::PhotonCollection;
+//using reco::PhotonRef;
 
 // If the analyzer does not use TFileService, please remove
 // the template argument to the base class so the class inherits
@@ -79,7 +84,7 @@ class SCRegressor : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
     // ----------member data ---------------------------
     //edm::EDGetTokenT<edm::View<reco::GsfElectron>> electronCollectionT_;
     edm::EDGetTokenT<reco::GsfElectronCollection> electronCollectionT_;
-    edm::EDGetTokenT<reco::PhotonCollection> photonCollectionT_;
+    edm::EDGetTokenT<PhotonCollection> photonCollectionT_;
     edm::EDGetTokenT<EcalRecHitCollection> EBRecHitCollectionT_;
     edm::EDGetTokenT<EcalRecHitCollection> EERecHitCollectionT_;
     edm::EDGetTokenT<EcalRecHitCollection> ESRecHitCollectionT_;

--- a/RecHitAnalyzer/plugins/RHAnalyzer_fillTRKlayersAtEBEE.cc
+++ b/RecHitAnalyzer/plugins/RHAnalyzer_fillTRKlayersAtEBEE.cc
@@ -71,8 +71,8 @@ void RecHitAnalyzer::branchesTRKlayersAtEBEE ( TTree* tree, edm::Service<TFileSe
     // Histograms for monitoring
     sprintf(htitle,"N(i#phi,i#eta);i#phi;i#eta");
     hTOB_EB[iL] = fs->make<TH2F>(hname, htitle,
-        EBDetId::MAX_IPHI  , EBDetId::MIN_IPHI-1, EBDetId::MAX_IPHI,
-        2*EBDetId::MAX_IETA,-EBDetId::MAX_IETA,   EBDetId::MAX_IETA );
+        EB_IPHI_MAX  , EB_IPHI_MIN-1, EB_IPHI_MAX,
+        2*EB_IETA_MAX,-EB_IETA_MAX,   EB_IETA_MAX );
     for ( int iz(0); iz < nEE; iz++ ) {
       const char *zside = (iz > 0) ? "p" : "m";
       sprintf(hname, "TOB_layer%d_EE%s",layer,zside);
@@ -83,8 +83,8 @@ void RecHitAnalyzer::branchesTRKlayersAtEBEE ( TTree* tree, edm::Service<TFileSe
       sprintf(htitle,"N(ix,iy);ix;iy");
       //hTOB_EE[iz][iL] = fs->make<TH2F>(hname, htitle,
       hTOB_EE[iL][iz] = fs->make<TH2F>(hname, htitle,
-          EEDetId::IX_MAX, EEDetId::IX_MIN-1, EEDetId::IX_MAX,
-          EEDetId::IY_MAX, EEDetId::IY_MIN-1, EEDetId::IY_MAX );
+          EE_MAX_IX, EE_MIN_IX-1, EE_MAX_IX,
+          EE_MAX_IY, EE_MIN_IY-1, EE_MAX_IY );
     } // iz
   } // iL
   for ( int iL(0); iL < nTEC; iL++ ) {
@@ -96,8 +96,8 @@ void RecHitAnalyzer::branchesTRKlayersAtEBEE ( TTree* tree, edm::Service<TFileSe
     // Histograms for monitoring
     sprintf(htitle,"N(i#phi,i#eta);i#phi;i#eta");
     hTEC_EB[iL] = fs->make<TH2F>(hname, htitle,
-        EBDetId::MAX_IPHI  , EBDetId::MIN_IPHI-1, EBDetId::MAX_IPHI,
-        2*EBDetId::MAX_IETA,-EBDetId::MAX_IETA,   EBDetId::MAX_IETA );
+        EB_IPHI_MAX  , EB_IPHI_MIN-1, EB_IPHI_MAX,
+        2*EB_IETA_MAX,-EB_IETA_MAX,   EB_IETA_MAX );
     for ( int iz(0); iz < nEE; iz++ ) {
       const char *zside = (iz > 0) ? "p" : "m";
       sprintf(hname, "TEC_layer%d_EE%s",layer,zside);
@@ -108,8 +108,8 @@ void RecHitAnalyzer::branchesTRKlayersAtEBEE ( TTree* tree, edm::Service<TFileSe
       sprintf(htitle,"N(ix,iy);ix;iy");
       //hTEC_EE[iz][iL] = fs->make<TH2F>(hname, htitle,
       hTEC_EE[iL][iz] = fs->make<TH2F>(hname, htitle,
-          EEDetId::IX_MAX, EEDetId::IX_MIN-1, EEDetId::IX_MAX,
-          EEDetId::IY_MAX, EEDetId::IY_MIN-1, EEDetId::IY_MAX );
+          EE_MAX_IX, EE_MIN_IX-1, EE_MAX_IX,
+          EE_MAX_IY, EE_MIN_IY-1, EE_MAX_IY );
     } // iz
   } // iL
   for ( int iL(0); iL < nTIB; iL++ ) {
@@ -121,8 +121,8 @@ void RecHitAnalyzer::branchesTRKlayersAtEBEE ( TTree* tree, edm::Service<TFileSe
     // Histograms for monitoring
     sprintf(htitle,"N(i#phi,i#eta);i#phi;i#eta");
     hTIB_EB[iL] = fs->make<TH2F>(hname, htitle,
-        EBDetId::MAX_IPHI  , EBDetId::MIN_IPHI-1, EBDetId::MAX_IPHI,
-        2*EBDetId::MAX_IETA,-EBDetId::MAX_IETA,   EBDetId::MAX_IETA );
+        EB_IPHI_MAX  , EB_IPHI_MIN-1, EB_IPHI_MAX,
+        2*EB_IETA_MAX,-EB_IETA_MAX,   EB_IETA_MAX );
     for ( int iz(0); iz < nEE; iz++ ) {
       const char *zside = (iz > 0) ? "p" : "m";
       sprintf(hname, "TIB_layer%d_EE%s",layer,zside);
@@ -133,8 +133,8 @@ void RecHitAnalyzer::branchesTRKlayersAtEBEE ( TTree* tree, edm::Service<TFileSe
       sprintf(htitle,"N(ix,iy);ix;iy");
       //hTIB_EE[iz][iL] = fs->make<TH2F>(hname, htitle,
       hTIB_EE[iL][iz] = fs->make<TH2F>(hname, htitle,
-          EEDetId::IX_MAX, EEDetId::IX_MIN-1, EEDetId::IX_MAX,
-          EEDetId::IY_MAX, EEDetId::IY_MIN-1, EEDetId::IY_MAX );
+          EE_MAX_IX, EE_MIN_IX-1, EE_MAX_IX,
+          EE_MAX_IY, EE_MIN_IY-1, EE_MAX_IY );
     } // iz
   } // iL
   for ( int iL(0); iL < nTID; iL++ ) {
@@ -146,8 +146,8 @@ void RecHitAnalyzer::branchesTRKlayersAtEBEE ( TTree* tree, edm::Service<TFileSe
     // Histograms for monitoring
     sprintf(htitle,"N(i#phi,i#eta);i#phi;i#eta");
     hTID_EB[iL] = fs->make<TH2F>(hname, htitle,
-        EBDetId::MAX_IPHI  , EBDetId::MIN_IPHI-1, EBDetId::MAX_IPHI,
-        2*EBDetId::MAX_IETA,-EBDetId::MAX_IETA,   EBDetId::MAX_IETA );
+        EB_IPHI_MAX  , EB_IPHI_MIN-1, EB_IPHI_MAX,
+        2*EB_IETA_MAX,-EB_IETA_MAX,   EB_IETA_MAX );
     for ( int iz(0); iz < nEE; iz++ ) {
       const char *zside = (iz > 0) ? "p" : "m";
       sprintf(hname, "TID_layer%d_EE%s",layer,zside);
@@ -158,8 +158,8 @@ void RecHitAnalyzer::branchesTRKlayersAtEBEE ( TTree* tree, edm::Service<TFileSe
       sprintf(htitle,"N(ix,iy);ix;iy");
       //hTID_EE[iz][iL] = fs->make<TH2F>(hname, htitle,
       hTID_EE[iL][iz] = fs->make<TH2F>(hname, htitle,
-          EEDetId::IX_MAX, EEDetId::IX_MIN-1, EEDetId::IX_MAX,
-          EEDetId::IY_MAX, EEDetId::IY_MIN-1, EEDetId::IY_MAX );
+          EE_MAX_IX, EE_MIN_IX-1, EE_MAX_IX,
+          EE_MAX_IY, EE_MIN_IY-1, EE_MAX_IY );
     } // iz
   } // iL
   for ( int iL(0); iL < nBPIX; iL++ ) {
@@ -171,8 +171,8 @@ void RecHitAnalyzer::branchesTRKlayersAtEBEE ( TTree* tree, edm::Service<TFileSe
     // Histograms for monitoring
     sprintf(htitle,"N(i#phi,i#eta);i#phi;i#eta");
     hBPIX_EB[iL] = fs->make<TH2F>(hname, htitle,
-        EBDetId::MAX_IPHI  , EBDetId::MIN_IPHI-1, EBDetId::MAX_IPHI,
-        2*EBDetId::MAX_IETA,-EBDetId::MAX_IETA,   EBDetId::MAX_IETA );
+        EB_IPHI_MAX  , EB_IPHI_MIN-1, EB_IPHI_MAX,
+        2*EB_IETA_MAX,-EB_IETA_MAX,   EB_IETA_MAX );
     for ( int iz(0); iz < nEE; iz++ ) {
       const char *zside = (iz > 0) ? "p" : "m";
       sprintf(hname, "BPIX_layer%d_EE%s",layer,zside);
@@ -183,8 +183,8 @@ void RecHitAnalyzer::branchesTRKlayersAtEBEE ( TTree* tree, edm::Service<TFileSe
       sprintf(htitle,"N(ix,iy);ix;iy");
       //hBPIX_EE[iz][iL] = fs->make<TH2F>(hname, htitle,
       hBPIX_EE[iL][iz] = fs->make<TH2F>(hname, htitle,
-          EEDetId::IX_MAX, EEDetId::IX_MIN-1, EEDetId::IX_MAX,
-          EEDetId::IY_MAX, EEDetId::IY_MIN-1, EEDetId::IY_MAX );
+          EE_MAX_IX, EE_MIN_IX-1, EE_MAX_IX,
+          EE_MAX_IY, EE_MIN_IY-1, EE_MAX_IY );
     } // iz
   } // iL
   for ( int iL(0); iL < nFPIX; iL++ ) {
@@ -196,8 +196,8 @@ void RecHitAnalyzer::branchesTRKlayersAtEBEE ( TTree* tree, edm::Service<TFileSe
     // Histograms for monitoring
     sprintf(htitle,"N(i#phi,i#eta);i#phi;i#eta");
     hFPIX_EB[iL] = fs->make<TH2F>(hname, htitle,
-        EBDetId::MAX_IPHI  , EBDetId::MIN_IPHI-1, EBDetId::MAX_IPHI,
-        2*EBDetId::MAX_IETA,-EBDetId::MAX_IETA,   EBDetId::MAX_IETA );
+        EB_IPHI_MAX  , EB_IPHI_MIN-1, EB_IPHI_MAX,
+        2*EB_IETA_MAX,-EB_IETA_MAX,   EB_IETA_MAX );
     for ( int iz(0); iz < nEE; iz++ ) {
       const char *zside = (iz > 0) ? "p" : "m";
       sprintf(hname, "FPIX_layer%d_EE%s",layer,zside);
@@ -208,8 +208,8 @@ void RecHitAnalyzer::branchesTRKlayersAtEBEE ( TTree* tree, edm::Service<TFileSe
       sprintf(htitle,"N(ix,iy);ix;iy");
       //hFPIX_EE[iz][iL] = fs->make<TH2F>(hname, htitle,
       hFPIX_EE[iL][iz] = fs->make<TH2F>(hname, htitle,
-          EEDetId::IX_MAX, EEDetId::IX_MIN-1, EEDetId::IX_MAX,
-          EEDetId::IY_MAX, EEDetId::IY_MIN-1, EEDetId::IY_MAX );
+          EE_MAX_IX, EE_MIN_IX-1, EE_MAX_IX,
+          EE_MAX_IY, EE_MIN_IY-1, EE_MAX_IY );
     } // iz
   } // iL
 
@@ -221,7 +221,7 @@ void fillTRKatEB ( EBDetId ebId, int iL, TH2F *hTRK_EB[], std::vector<float> vTR
   ieta_ = ebId.ieta() > 0 ? ebId.ieta()-1 : ebId.ieta();
   // Fill histograms for monitoring
   hTRK_EB[iL]->Fill( iphi_, ieta_ );
-  idx_ = ebId.hashedIndex(); // (ieta_+EBDetId::MAX_IETA)*EBDetId::MAX_IPHI + iphi_
+  idx_ = ebId.hashedIndex(); // (ieta_+EB_IETA_MAX)*EB_IPHI_MAX + iphi_
   // Fill vectors for images
   vTRK_EB_[iL][idx_] += 1.;
 }
@@ -235,7 +235,7 @@ void fillTRKatEE ( EEDetId eeId, int iL, TH2F *hTRK_EE[][nEE], std::vector<float
   // Fill histograms for monitoring
   hTRK_EE[iL][iz_]->Fill( ix_, iy_ );
   // Create hashed Index: maps from [iy][ix] -> [idx_]
-  idx_ = iy_*EEDetId::IX_MAX + ix_;
+  idx_ = iy_*EE_MAX_IX + ix_;
   // Fill vectors for images
   vTRK_EE_[iL][iz_][idx_] += 1.;
 }

--- a/RecHitAnalyzer/plugins/RHAnalyzer_fillTRKvolumeAtEBEE.cc
+++ b/RecHitAnalyzer/plugins/RHAnalyzer_fillTRKvolumeAtEBEE.cc
@@ -21,18 +21,18 @@ void RecHitAnalyzer::branchesTRKvolumeAtEBEE ( TTree* tree, edm::Service<TFileSe
   // Histograms for monitoring
   /*
   hTRK_EB = fs->make<TH3F>("TRK_volume_EB", "N(#phi,#eta,#rho);#phi;#eta;#rho",
-      EBDetId::MAX_IPHI  ,-TMath::Pi(),         TMath::Pi(),
-      2*EBDetId::MAX_IETA,-1.479,               1.479,
+      EB_IPHI_MAX  ,-TMath::Pi(),         TMath::Pi(),
+      2*EB_IETA_MAX,-1.479,               1.479,
       12,                  0.,                  110. );
   */
   hTRK_EB = fs->make<TH3F>("TRK_volume_EB", "N(iphi,ieta,#rho);iphi;ieta;#rho",
-      EBDetId::MAX_IPHI  , EB_IPHI_MIN-1, EB_IPHI_MAX,
+      EB_IPHI_MAX  , EB_IPHI_MIN-1, EB_IPHI_MAX,
       2*EB_IETA_MAX      ,-EB_IETA_MAX  , EB_IETA_MAX, 
       12                 ,0.            , 110. );
   hTRK_EB_eta = fs->make<TH1F>("TRK_eta_EB", "N(eta);eta",
-      2*EBDetId::MAX_IETA,-1.479,               1.479 );
+      2*EB_IETA_MAX,-1.479,               1.479 );
   hTRK_EB_phi = fs->make<TH1F>("TRK_phi_EB", "N(phi);phi",
-      EBDetId::MAX_IPHI  ,-TMath::Pi(),         TMath::Pi() );
+      EB_IPHI_MAX  ,-TMath::Pi(),         TMath::Pi() );
   hTRK_EB_rho = fs->make<TH1F>("TRK_rho_EB", "N(rho);rho",
       120,                 0.,                  110. );
 
@@ -50,8 +50,8 @@ void RecHitAnalyzer::branchesTRKvolumeAtEBEE ( TTree* tree, edm::Service<TFileSe
     sprintf(hname, "TRK_volume_EE%s",zside);
     sprintf(htitle,"N(x,y,z);x;y,z");
     hTRK_EE[iz] = fs->make<TH3F>(hname, htitle,
-        EEDetId::IX_MAX, -100., 100.,
-        EEDetId::IY_MAX, -100., 100.,
+        EE_MAX_IX, -100., 100.,
+        EE_MAX_IY, -100., 100.,
         28,               zMin, zMax );
   } // iz
   hTRK_EE_z = fs->make<TH1F>("TRK_EE_z", "N(z);z",
@@ -134,7 +134,7 @@ void RecHitAnalyzer::fillTRKvolumeAtEBEE ( const edm::Event& iEvent, const edm::
       ieta_ = ebId.ieta() > 0 ? ebId.ieta()-1 : ebId.ieta();
       // Fill histograms for monitoring
       hTRK_EB->Fill( iphi_, ieta_ );
-      idx_ = ebId.hashedIndex(); // (ieta_+EBDetId::MAX_IETA)*EBDetId::MAX_IPHI + iphi_
+      idx_ = ebId.hashedIndex(); // (ieta_+EB_IETA_MAX)*EB_IPHI_MAX + iphi_
       // Fill vectors for images
       vTRK_EB_[idx_] += 1.;
     } else if ( id.subdetId() == EcalEndcap ) {
@@ -145,7 +145,7 @@ void RecHitAnalyzer::fillTRKvolumeAtEBEE ( const edm::Event& iEvent, const edm::
       // Fill histograms for monitoring
       hTRK_EE[iz_]->Fill( ix_, iy_ );
       // Create hashed Index: maps from [iy][ix] -> [idx_]
-      idx_ = iy_*EEDetId::IX_MAX + ix_;
+      idx_ = iy_*EE_MAX_IX + ix_;
       // Fill vectors for images
       vTRK_EE_[iz_][idx_] += 1.;
     } 

--- a/RecHitAnalyzer/plugins/SCRegressor_fillPhoVars.cc
+++ b/RecHitAnalyzer/plugins/SCRegressor_fillPhoVars.cc
@@ -3,17 +3,23 @@
 // Initialize branches _____________________________________________________//
 void SCRegressor::branchesPhoVars ( TTree* tree, edm::Service<TFileService> &fs )
 {
-  RHTree->Branch("pho_r9",             &vPho_r9_);
-  RHTree->Branch("pho_sieie",          &vPho_sieie_);
-  RHTree->Branch("pho_phoIso",         &vPho_phoIso_);
-  RHTree->Branch("pho_chgIso",         &vPho_chgIso_);
-  RHTree->Branch("pho_chgIsoWrongVtx", &vPho_chgIsoWrongVtx_);
-  RHTree->Branch("pho_Eraw",           &vPho_Eraw_);
-  RHTree->Branch("pho_phiWidth",       &vPho_phiWidth_);
-  RHTree->Branch("pho_etaWidth",       &vPho_etaWidth_);
-  RHTree->Branch("pho_scEta",          &vPho_scEta_);
-  RHTree->Branch("pho_sieip",          &vPho_sieip_);
-  RHTree->Branch("pho_s4",             &vPho_s4_);
+
+  tree->Branch("pho_pT",    &vPho_pT_);
+  tree->Branch("pho_E",     &vPho_E_);
+  tree->Branch("pho_eta",   &vPho_eta_);
+  tree->Branch("pho_phi",   &vPho_phi_);
+
+  tree->Branch("pho_r9",             &vPho_r9_);
+  tree->Branch("pho_sieie",          &vPho_sieie_);
+  tree->Branch("pho_phoIso",         &vPho_phoIso_);
+  tree->Branch("pho_chgIso",         &vPho_chgIso_);
+  tree->Branch("pho_chgIsoWrongVtx", &vPho_chgIsoWrongVtx_);
+  tree->Branch("pho_Eraw",           &vPho_Eraw_);
+  tree->Branch("pho_phiWidth",       &vPho_phiWidth_);
+  tree->Branch("pho_etaWidth",       &vPho_etaWidth_);
+  tree->Branch("pho_scEta",          &vPho_scEta_);
+  tree->Branch("pho_sieip",          &vPho_sieip_);
+  tree->Branch("pho_s4",             &vPho_s4_);
 
 } // branchesPhoVars()
 
@@ -30,7 +36,7 @@ void SCRegressor::fillPhoVars ( const edm::Event& iEvent, const edm::EventSetup&
   //std::cout << "rho:" << *(rhoH.product()) << std::endl;
   */
 
-  edm::Handle<reco::PhotonCollection> photons;
+  edm::Handle<PhotonCollection> photons;
   iEvent.getByToken(photonCollectionT_, photons);
   /*
   edm::Handle<reco::GenParticleCollection> genParticles;
@@ -43,24 +49,23 @@ void SCRegressor::fillPhoVars ( const edm::Event& iEvent, const edm::EventSetup&
   */
 
   ////////// Store kinematics //////////
-  /*
+
   vPho_pT_.clear();
   vPho_E_.clear();
   vPho_eta_.clear();
   vPho_phi_.clear();
   vPho_r9_.clear();
   vPho_sieie_.clear();
-  for ( auto const& mG : mGenPi0_RecoPho ) { 
-    reco::PhotonRef iPho( photons, mG.second[0] );
+  for ( int iP : vRegressPhoIdxs_ ) {
+
+    PhotonRef iPho( photons, iP );
     // Fill branch arrays
     vPho_pT_.push_back( iPho->pt() );
     vPho_E_.push_back( iPho->energy() );
     vPho_eta_.push_back( iPho->eta() );
     vPho_phi_.push_back( iPho->phi() );
-    vPho_r9_.push_back( iPho->full5x5_r9() );
-    vPho_sieie_.push_back( iPho->full5x5_sigmaIetaIeta() );
   } // photons
-  */
+  
   vPho_r9_.clear(); 
   vPho_sieie_.clear(); 
   vPho_phoIso_.clear(); 
@@ -72,9 +77,12 @@ void SCRegressor::fillPhoVars ( const edm::Event& iEvent, const edm::EventSetup&
   vPho_scEta_.clear(); 
   vPho_sieip_.clear(); 
   vPho_s4_.clear(); 
-  for ( auto const& mG : mGenPi0_RecoPho ) { 
 
-    reco::PhotonRef iPho( photons, mG.second[0] );
+  //for ( auto const& mG : mGenPi0_RecoPho ) { 
+  for ( int iP : vRegressPhoIdxs_ ) {
+
+    //PhotonRef iPho( photons, mG.second[0] );
+    PhotonRef iPho( photons, iP );
     reco::SuperClusterRef const& iSC = iPho->superCluster();
     std::vector<float> vCov = clusterTools.localCovariances( *(iSC->seed()) );
 

--- a/RecHitAnalyzer/plugins/SCRegressor_runDiPhotonSel.cc
+++ b/RecHitAnalyzer/plugins/SCRegressor_runDiPhotonSel.cc
@@ -15,26 +15,38 @@ struct pho_obj {
 // Run event selection ___________________________________________________________________//
 bool SCRegressor::runDiPhotonSel ( const edm::Event& iEvent, const edm::EventSetup& iSetup ) {
 
-  edm::Handle<reco::PhotonCollection> photons;
+  edm::Handle<PhotonCollection> photons;
   iEvent.getByToken(photonCollectionT_, photons);
 
   ////////// Apply selection //////////
 
-  // Ensure two reco photons 
   if ( debug ) std::cout << " Pho collection size:" << photons->size() << std::endl;
+
+  // Ensure exactly 2 reco photons > 5 GeV
+  std::vector<unsigned int> vRecoPhoIdxs;
+  for ( unsigned int iP = 0; iP < photons->size(); iP++ ) {
+    PhotonRef iPho( photons, iP );
+    if ( std::abs(iPho->pt()) < 5. ) continue;
+    vRecoPhoIdxs.push_back( iP );
+  }
+  if ( vRecoPhoIdxs.size() != 2 ) return false;
+  //if ( vRecoPhoIdxs.size() > 3 ) return false;
+  if ( debug ) std::cout << " Reco pho size:" << vRecoPhoIdxs.size() << std::endl;
+
+  // Ensure two presel photons 
   //std::vector<int> vPhoIdxs;
   //math::PtEtaPhiELorentzVectorD vDiPho;
   std::vector<pho_obj> vPhos;
-  for ( unsigned int iP = 0; iP < photons->size(); iP++ ) {
+  for ( unsigned int iP : vRecoPhoIdxs ) {
 
-    reco::PhotonRef iPho( photons, iP );
+    PhotonRef iPho( photons, iP );
 
     if ( std::abs(iPho->pt()) < 18. ) continue;
     if ( std::abs(iPho->eta()) > 1.44 ) continue;
     if ( iPho->full5x5_r9() < 0.5 ) continue;
-    //if ( iPho->hadTowOverEm() > 0.07 ) continue;
+    if ( iPho->hadTowOverEm() > 0.07 ) continue;
     if ( iPho->full5x5_sigmaIetaIeta() > 0.0105 ) continue;
-    //if ( iPho->hasPixelSeed() == true ) continue;
+    if ( iPho->hasPixelSeed() == true ) continue;
     if ( debug ) std::cout << " >> pT:" << iPho->pt() << " eta:" << iPho->eta() << " phi: " << iPho->phi() << " E:" << iPho->energy() << std::endl;
 
     //vDiPho += iPho->p4();
@@ -43,13 +55,13 @@ bool SCRegressor::runDiPhotonSel ( const edm::Event& iEvent, const edm::EventSet
     vPhos.push_back( Pho_obj );
 
   } // reco photons
-  if ( debug ) std::cout << " Reco pho size:" << vPhos.size() << std::endl;
+  if ( debug ) std::cout << " Presel pho size:" << vPhos.size() << std::endl;
   if ( vPhos.size() < 2 ) return false;
 
   // Sort photons by pT, for abitrary N 
   std::sort( vPhos.begin(), vPhos.end(), [](auto const &a, auto const &b) { return a.pt > b.pt; } );
   for ( unsigned int iP = 0; iP < vPhos.size(); iP++ ) {
-    reco::PhotonRef iPho( photons, vPhos[iP].idx );
+    PhotonRef iPho( photons, vPhos[iP].idx );
     if ( debug ) std::cout << " >> pT:" << iPho->pt() << " eta:" << iPho->eta() << " phi: " << iPho->phi() << " E:" << iPho->energy() << std::endl;
   }
   // Check if any photon pairing passes invariant mass cut
@@ -57,12 +69,12 @@ bool SCRegressor::runDiPhotonSel ( const edm::Event& iEvent, const edm::EventSet
   bool passedMassCut = false;
   for ( unsigned int j = 0; j < vPhos.size()-1; j++ ) {
 
-    reco::PhotonRef jPho( photons, vPhos[j].idx );
+    PhotonRef jPho( photons, vPhos[j].idx );
 
     for ( unsigned int k = 1; k < vPhos.size(); k++ ) {
 
       if ( k <= j ) continue;
-      reco::PhotonRef kPho( photons, vPhos[k].idx );
+      PhotonRef kPho( photons, vPhos[k].idx );
       ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > vDiPho = jPho->p4() + kPho->p4();
       if ( debug ) std::cout << " >> m0:" << vDiPho.mass() << std::endl;
 
@@ -86,7 +98,7 @@ bool SCRegressor::runDiPhotonSel ( const edm::Event& iEvent, const edm::EventSet
   vPreselPhoIdxs_.clear();
   for ( unsigned int iP = 0; iP < vPhoIdxs.size(); iP++ ) {
 
-    reco::PhotonRef iPho( photons, vPhoIdxs[iP] );
+    PhotonRef iPho( photons, vPhoIdxs[iP] );
 
     if ( std::abs(iPho->pt()) < ptCut[iP] ) continue;
     if ( std::abs(iPho->pt()) < m0_/ptOmCut[iP] ) continue;
@@ -106,14 +118,14 @@ bool SCRegressor::runDiPhotonSel ( const edm::Event& iEvent, const edm::EventSet
 void SCRegressor::fillDiPhotonSel ( const edm::Event& iEvent, const edm::EventSetup& iSetup )
 {
 
-  edm::Handle<reco::PhotonCollection> photons;
+  edm::Handle<PhotonCollection> photons;
   iEvent.getByToken(photonCollectionT_, photons);
 
   // Fill kinematic variables
   float dphi[2] = { 0., 0. };
   vFC_inputs_.clear();
   for ( unsigned int iP = 0; iP < vRegressPhoIdxs_.size(); iP++ ) {
-    reco::PhotonRef iPho( photons, vRegressPhoIdxs_[iP] );
+    PhotonRef iPho( photons, vRegressPhoIdxs_[iP] );
     vFC_inputs_.push_back( iPho->pt()/m0_ );
     vFC_inputs_.push_back( iPho->eta() );
     dphi[iP] = iPho->phi();

--- a/RecHitAnalyzer/python/SCRegressor_cfg.py
+++ b/RecHitAnalyzer/python/SCRegressor_cfg.py
@@ -51,10 +51,14 @@ process.es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')
 process.fevt = cms.EDAnalyzer('SCRegressor'
     #, EBRecHitCollection = cms.InputTag('ecalRecHit:EcalRecHitsEB')
     , gsfElectronCollection = cms.InputTag('gedGsfElectrons')
-    , gedPhotonCollection = cms.InputTag('gedPhotons')
-    , reducedEBRecHitCollection = cms.InputTag('reducedEcalRecHitsEB')
-    , reducedEERecHitCollection = cms.InputTag('reducedEcalRecHitsEE')
-    , reducedESRecHitCollection = cms.InputTag('reducedEcalRecHitsES')
+    #, photonCollection = cms.InputTag('gedPhotons')
+    , photonCollection = cms.InputTag('slimmedPhotons')
+    #, reducedEBRecHitCollection = cms.InputTag('reducedEcalRecHitsEB')
+    #, reducedEERecHitCollection = cms.InputTag('reducedEcalRecHitsEE')
+    #, reducedESRecHitCollection = cms.InputTag('reducedEcalRecHitsES')
+    , reducedEBRecHitCollection = cms.InputTag('reducedEgamma:reducedEBRecHits')
+    , reducedEERecHitCollection = cms.InputTag('reducedEgamma:reducedEERecHits')
+    , reducedESRecHitCollection = cms.InputTag('reducedEgamma:reducedESRecHits')
     , genParticleCollection = cms.InputTag('genParticles')
     , genJetCollection = cms.InputTag('ak4GenJets')
     , trackCollection = cms.InputTag("generalTracks")
@@ -66,4 +70,13 @@ process.TFileService = cms.Service("TFileService",
     fileName = cms.string(options.outputFile)
     )
 
-process.p = cms.Path(process.fevt)
+process.hltFilter = cms.EDFilter("HLTHighLevel",
+                                          eventSetupPathsKey = cms.string(''),
+                                          TriggerResultsTag = cms.InputTag("TriggerResults","","HLT"),
+                                          HLTPaths = cms.vstring('HLT_Diphoton30PV_18PV_R9Id_AND_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55_v*'),
+                                          andOr = cms.bool(True),
+                                          throw = cms.bool(False)
+                                          )
+
+#process.p = cms.Path(process.fevt)
+process.p = cms.Path(process.hltFilter*process.fevt)

--- a/runSCRegressor.py
+++ b/runSCRegressor.py
@@ -16,7 +16,12 @@ cfg='RecHitAnalyzer/python/SCRegressor_cfg.py'
 #inputFiles_='/store/user/lpcml/mandrews/AODSIM/DoublePhotonPt15To100_pythia8_noPU_AODSIM/190219_231402/0000/step_full_1.root'
 #inputFiles_='/store/user/lpcml/mandrews/AODSIM/DoublePi0Pt15To100_m000_pythia8_noPU_AODSIM/190220_040632/0000/step_full_1.root'
 #inputFiles_='/store/user/lpcml/mandrews/AODSIM/SM2gamma_1j_1M_2016_25ns_Moriond17MC_PoissonOOTPU_AODSIM/180904_071354/0000/step_full_1.root'
-inputFiles_='/store/user/lpcml/mandrews/AODSIM/DoublePi0Pt15To100_m0To1600_pythia8_noPU_AODSIM_mlog_ptexp/190217_185619/0000/step_full_1.root'
+#inputFiles_='/store/user/lpcml/mandrews/AODSIM/DoublePi0Pt15To100_m0To1600_pythia8_noPU_AODSIM_mlog_ptexp/190217_185619/0000/step_full_1.root'
+#inputFiles_='/store/mc/RunIIFall17MiniAODv2/DiPhotonJets_MGG-80toInf_13TeV_amcatnloFXFX_pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/100000/72CD8425-3B87-E811-AEA5-24BE05CEADA1.root'
+#inputFiles_='/store/mc/RunIIFall17MiniAODv2/GluGluHToGG_M125_13TeV_amcatnloFXFX_pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/90000/BC2864DE-5B42-E811-9C51-0025905A6138.root'
+#inputFiles_='/store/mc/RunIIFall17MiniAODv2/DYToEE_M-50_NNPDF31_13TeV-powheg-pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/10000/544FA228-5845-E811-A88A-782BCB539B14.root'
+inputFiles_='/store/mc/RunIIFall17MiniAODv2/GJet_Pt-20to40_DoubleEMEnriched_MGG-80toInf_TuneCP5_13TeV_Pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/00000/288ED03F-6C42-E811-96EC-0CC47A4C8E98.root '
+#inputFiles_='/store/data/Run2017B/DoubleEG/MINIAOD/31Mar2018-v1/80000/FAC7DC8A-3737-E811-8BA7-6CC2173DC380.root'
 
 #inputFiles_='file:step_full_filtered.root'
 maxEvents_=-1


### PR DESCRIPTION
**SCRegressor:**
- Centralize use of pat::Photon* classes for miniAOD studies
- Fix photon veto in pi0/photon selection to loop over all reco photons
- Centralize filling of all reco photons to fillPhoVars
- Add HLT filter

**RHAnalyzer:**
- Fix naming of ECAL constants in fillTRK*AtEBEE files